### PR TITLE
Add new private to properly manage get_repos together with tests.

### DIFF
--- a/tests/testthat/test-class_github.R
+++ b/tests/testthat/test-class_github.R
@@ -29,6 +29,24 @@ test_that("Check correctly if API url is of Enterprise or Public Github", {
   expect_equal(priv_enterp$check_enterprise(git_hub_enterprise$rest_api_url), TRUE)
 })
 
+test_that("Private get_all_repos_from_owner pulls correctly repositories", {
+
+  orgs <- c("openpharma", "r-world-devs", "pharmaverse")
+
+  purrr::walk(orgs, function(org) {
+
+    repos_n <- perform_get_request(endpoint = paste0("https://api.github.com/orgs/", org),
+                                   token = Sys.getenv("GITHUB_PAT"))[["public_repos"]]
+
+    expect_equal(
+      length(priv_publ$get_all_repos_from_owner(repo_owner = org)),
+      repos_n
+    )
+
+  })
+
+})
+
 test_that("Get_repos methods pulls repositories from GitHub and translates output into data.frame", {
   repos <- git_hub_public$get_repos(by = "org")
 

--- a/tests/testthat/test-class_gitlab.R
+++ b/tests/testthat/test-class_gitlab.R
@@ -4,6 +4,26 @@ git_lab_public <- GitLab$new(
   orgs = c("erasmusmc-public-health")
 )
 
+priv_publ <- environment(git_lab_public$initialize)$private
+
+test_that("Private get_all_repos_from_owner pulls correctly repositories", {
+  testthat::skip_on_ci()
+  orgs <- c("erasmusmc-public-health")
+
+  purrr::walk(orgs, function(group) {
+
+    repos_n <- length(perform_get_request(endpoint = paste0("https://gitlab.com/api/v4/groups/", group),
+                                          token = Sys.getenv("GITLAB_PAT"))[["projects"]])
+
+    expect_equal(
+      length(priv_publ$get_all_repos_from_group(project_group = group)),
+      repos_n
+    )
+
+  })
+
+})
+
 test_that("Get_repos methods pulls repositories from GitLab and translates output into data.frame", {
   testthat::skip_on_ci()
   repos <- git_lab_public$get_repos(by = "org")


### PR DESCRIPTION
This ensures that all repos are pulled for the owner/group. Before only first page was drawn (if there were more than 100 repos, it did not show them).