### PR TITLE
Create wrapper for pulling one page, and other reoganization.

### DIFF
--- a/R/GitLab.R
+++ b/R/GitLab.R
@@ -12,9 +12,6 @@ GitLab <- R6::R6Class("GitLab",
   cloneable = FALSE,
   public = list(
 
-    #' @field repos_endpoint An expression for repositories endpoint.
-    repos_endpoint = rlang::expr(paste0(self$rest_api_url, "/groups/", org, "/projects")),
-
     #' @field repo_contributors_endpoint An expression for repositories contributors endpoint.
     repo_contributors_endpoint = rlang::expr(paste0(self$rest_api_url, "/projects/", repo$id, "/repository/contributors")),
 
@@ -45,9 +42,8 @@ GitLab <- R6::R6Class("GitLab",
       still_more_hits <- TRUE
       while (length(orgs_list) < org_limit || !still_more_hits) {
         pb$tick()
-        orgs_page <- get_response(
-          endpoint = paste0(self$rest_api_url, "/groups?all_available=true&per_page=100&page=", o_page),
-          token = private$token
+        orgs_page <- private$rest_response(
+          endpoint = paste0(self$rest_api_url, "/groups?all_available=true&per_page=100&page=", o_page)
         )
         if (length(orgs_page) > 0) {
           orgs_list <- append(orgs_list, orgs_page)
@@ -77,7 +73,7 @@ GitLab <- R6::R6Class("GitLab",
 
       team <- paste0(team, collapse = '", "')
 
-      gql_query <- self$graphql$groups_by_user(team)
+      gql_query <- self$groups_by_user(team)
 
       json_data <- gql_response(
                      api_url = paste0(self$gql_api_url),
@@ -99,6 +95,32 @@ GitLab <- R6::R6Class("GitLab",
       return(org_names)
     },
 
+    #' @description A method to pull all repositories for an organization.
+    #' @param org A character, an organization:\itemize{\item{GitHub - owners o
+    #'   repositories} \item{GitLab - group of projects.}}
+    #' @return A list.
+    pull_repos_from_org = function(org) {
+      repos_list <- list()
+      r_page <- 1
+      repeat {
+        repos_page <- private$rest_response(
+          endpoint = paste0(self$rest_api_url, "/groups/", org, "/projects?per_page=100&page=", r_page)
+        )
+        if (length(repos_page) > 0) {
+          repos_list <- append(repos_list, repos_page)
+          r_page <- r_page + 1
+        } else {
+          break
+        }
+      }
+
+      repos_list <- repos_list %>%
+        private$pull_repos_contributors() %>%
+        private$pull_repos_issues()
+
+      repos_list
+    },
+
     #' @description Method to pull repositories' issues.
     #' @param repos_list A list of repositories.
     #' @return A list of repositories.
@@ -106,9 +128,8 @@ GitLab <- R6::R6Class("GitLab",
       projects_ids <- unique(purrr::map_chr(repos_list, ~ as.character(.$id)))
 
       repos_list <- purrr::map(projects_ids, function(project_id) {
-        issues_stats <- get_response(
-          endpoint = paste0(self$rest_api_url, "/projects/", project_id, "/issues_statistics"),
-          token = private$token
+        issues_stats <- private$rest_response(
+          endpoint = paste0(self$rest_api_url, "/projects/", project_id, "/issues_statistics")
         )
 
         issues_stats
@@ -144,9 +165,8 @@ GitLab <- R6::R6Class("GitLab",
       projects_id <- unique(purrr::map_chr(repos_list, ~ as.character(.$id)))
 
       projects_language_list <- purrr::map(projects_id, function(x) {
-        get_response(
-          endpoint = paste0(self$rest_api_url, "/projects/", x, "/languages"),
-          token = private$token
+        private$rest_response(
+          endpoint = paste0(self$rest_api_url, "/projects/", x, "/languages")
         )
       })
 
@@ -203,8 +223,9 @@ GitLab <- R6::R6Class("GitLab",
       groups_id <- private$get_group_id(org)
 
       while (still_more_hits | page < page_max) {
-        resp <- get_response(paste0(self$rest_api_url, "/groups/", groups_id, "/search?scope=blobs&search=", phrase, "&per_page=100&page=", page),
-          token = private$token
+        resp <- private$rest_response(
+          paste0(self$rest_api_url, "/groups/", groups_id,
+                 "/search?scope=blobs&search=", phrase, "&per_page=100&page=", page)
         )
 
         if (length(resp) == 0) {
@@ -247,7 +268,7 @@ GitLab <- R6::R6Class("GitLab",
       commits_list <- purrr::map(projects_ids, function(x) {
         pb$tick()
 
-        get_response(
+        private$rest_response(
           endpoint = paste0(
             self$rest_api_url,
             "/projects/",
@@ -257,8 +278,7 @@ GitLab <- R6::R6Class("GitLab",
             "'&until='",
             date_to_gts(date_until),
             "'&with_stats=true"
-          ),
-          token = private$token
+          )
         )
       })
 
@@ -334,8 +354,7 @@ GitLab <- R6::R6Class("GitLab",
     #' @param project_group A character, a group of projects.
     #' @return An integer, id of group.
     get_group_id = function(project_group) {
-      get_response(paste0(self$rest_api_url, "/groups/", project_group),
-        token = private$token
+      private$rest_response(paste0(self$rest_api_url, "/groups/", project_group)
       )[["id"]]
     }
   )

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -527,7 +527,7 @@ GitStats <- R6::R6Class("GitStats",
           } else if (client$git_service == "GitHub") {
             client$rest_api_url
           }
-          get_response(endpoint = check_endpoint,
+          private$rest_response(endpoint = check_endpoint,
                        token = priv$token)
         },
         message = function(m) {

--- a/R/GraphQL.R
+++ b/R/GraphQL.R
@@ -1,14 +1,15 @@
 #' @title A GraphQL class
 #' @description An object with methods to build GraphQL Queries.
 
-GraphQL <- R6::R6Class("GraphQL",
+GraphQLQuery <- R6::R6Class("GraphQLQuery",
+
                        public = list(
 
                          #' @description Prepare query to pull repositories for GitHub organization.
                          #' @param org An organization.
                          #' @param cursor An endCursor.
                          #' @return A query.
-                         gh_repos_by_org = function(org, cursor) {
+                         repos_by_org = function(org, cursor) {
 
                            if (nchar(cursor) == 0) {
                              after_cursor <- cursor
@@ -33,6 +34,8 @@ GraphQL <- R6::R6Class("GraphQL",
                                       name
                                       stargazerCount
                                       forkCount
+                                      createdAt
+                                      pushedAt
                                     }
                                   }
                                 }
@@ -44,7 +47,7 @@ GraphQL <- R6::R6Class("GraphQL",
                          #' @param user A user login.
                          #' @param cursor An endCursor.
                          #' @return A query.
-                         gh_repos_by_user = function(user) {
+                         repos_by_user = function(user) {
 
                            paste0('{
                             user(login: "', user, '"){
@@ -85,7 +88,7 @@ GraphQL <- R6::R6Class("GraphQL",
                          #' @param cursor An endCursor.
                          #' @param author_id An Id of an author.
                          #' @return A query.
-                         gh_commits = function(org, repo, since, until, cursor = '', author_id = '') {
+                         commits_by_repo = function(org, repo, since, until, cursor = '', author_id = '') {
 
                            if (nchar(cursor) == 0) {
                              after_cursor <- cursor
@@ -136,7 +139,7 @@ GraphQL <- R6::R6Class("GraphQL",
                          #' @description GitLab. Method to build query to pull groups by users.
                          #' @param team A string of team members.
                          #' @return A query.
-                         gl_groups_by_user = function(team) {
+                         groups_by_user = function(team) {
                            paste0('{
                                     users(usernames: ["', team, '"]) {
                                       pageInfo {
@@ -157,6 +160,6 @@ GraphQL <- R6::R6Class("GraphQL",
                                       }
                                     }
                                   }')
-                         }
+                          }
                        )
 )

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,26 +1,6 @@
 #' @importFrom httr2 request req_headers req_perform resp_body_json
 #' @importFrom cli cli_abort
 #'
-#' @name get_response
-#'
-#' @description A wrapper for httr2 functions to perform get request to REST API endpoints.
-#'
-#' @param endpoint An API endpoint.
-#' @param token An API token.
-#'
-#' @returns A content of response formatted to list.
-#'
-get_response <- function(endpoint, token) {
-
-  resp <- perform_request(endpoint, token)
-  if (!is.null(resp)) {
-    result <- resp %>% httr2::resp_body_json(check_type = FALSE)
-  } else {
-    result <- list()
-  }
-
-  return(result)
-}
 
 perform_request <- function(endpoint, token) {
 
@@ -89,21 +69,4 @@ resp_error_body <- function(resp) {
     message <- c(message, paste0("See docs at <", body$documentation_url, ">"))
   }
   message
-}
-
-#' @description Wrapper of GraphQL API request and response.
-#' @param api_url A url of GraphQL API.
-#' @param gql_query A string with GraphQL query.
-#' @param token a token.
-#' @return A list.
-gql_response <- function(api_url,
-                         gql_query,
-                         token) {
-
-  request(paste0(api_url, "?")) %>%
-    httr2::req_headers("Authorization" = paste0("Bearer ", token)) %>%
-    httr2::req_body_json(list(query=gql_query, variables="null")) %>%
-    httr2::req_perform() %>%
-    httr2::resp_body_json()
-
 }

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -1,4 +1,4 @@
-test_that("`get_response()` returns proper status when token is empty or invalid", {
+test_that("`private$rest_response()` returns proper status when token is empty or invalid", {
   testthat::skip_on_ci()
 
   wrong_tokens <- c("","bad_token")
@@ -6,7 +6,7 @@ test_that("`get_response()` returns proper status when token is empty or invalid
   purrr::walk(
     wrong_tokens,
     ~expect_message(
-       get_response(
+       private$rest_response(
          endpoint = "https://api.github.com/org/openpharma",
          token = .
        ),
@@ -16,11 +16,11 @@ test_that("`get_response()` returns proper status when token is empty or invalid
 
 })
 
-test_that("`get_response()` throws error on bad host", {
+test_that("`private$rest_response()` throws error on bad host", {
   bad_host <- "https://github.bad_host.com"
 
   expect_error(
-    get_response(
+    private$rest_response(
       endpoint = paste0(bad_host, "/orgs/good_org"),
       token = Sys.getenv("GITHUB_PAT")
     ),
@@ -28,11 +28,11 @@ test_that("`get_response()` throws error on bad host", {
   )
 })
 
-test_that("`get_response()` returns proper status", {
+test_that("`private$rest_response()` returns proper status", {
   bad_endpoint <- "https://api.github.com/orgs/everybody_loves_somebody"
 
   expect_message(
-    get_response(
+    private$rest_response(
       endpoint = bad_endpoint,
       token = Sys.getenv("GITHUB_PAT")
     ),

--- a/tests/testthat/test-pull_repos.R
+++ b/tests/testthat/test-pull_repos.R
@@ -111,7 +111,7 @@ test_that("`pull_repos_from_org()` pulls correctly repositories for GitLab", {
   )
 
   purrr::walk(orgs, function(group) {
-    repos_n <- length(get_response(
+    repos_n <- length(private$rest_response(
       endpoint = paste0("https://gitlab.com/api/v4/groups/", group),
       token = Sys.getenv("GITLAB_PAT")
     )[["projects"]])

--- a/tests/testthat/test-search_response.R
+++ b/tests/testthat/test-search_response.R
@@ -8,7 +8,7 @@ test_github_priv <- environment(test_github$initialize)$private
 
 test_that("`search_response()` performs search with limit under 100", {
   search_endpoint <- "https://api.github.com/search/code?q='covid'+user:pharmaverse"
-  total_n <- get_response(search_endpoint,
+  total_n <- private$rest_response(search_endpoint,
                           token = Sys.getenv("GITHUB_PAT"))[["total_count"]]
   expect_type(
     test_github_priv$search_response(
@@ -22,7 +22,7 @@ test_that("`search_response()` performs search with limit under 100", {
 
 test_that("`search_response()` performs search with limit over 100 and under 1000", {
   search_endpoint <- "https://api.github.com/search/code?q='maps'+user:eurostat"
-  total_n <- get_response(search_endpoint,
+  total_n <- private$rest_response(search_endpoint,
                           token = Sys.getenv("GITHUB_PAT"))[["total_count"]]
   expect_type(
     test_github_priv$search_response(


### PR DESCRIPTION
Other: better reflect name of `GraphQLQuery` object, move REST and GraphQL response wrappers to `GitService` class and other organizational activities.