### PR TITLE
Fix filtering by language.

### DIFF
--- a/R/EngineGraphQLGitHub.R
+++ b/R/EngineGraphQLGitHub.R
@@ -162,12 +162,14 @@ EngineGraphQLGitHub <- R6::R6Class("EngineGraphQLGitHub",
     pull_repos_from_team = function(team) {
 
       repos_from_team <- list()
-      for (login in team) {
-        user_repos <-
-          private$pull_repos(from = "user",
-                             user = login)
-        repos_from_team <-
-          append(repos_from_team, user_repos)
+      for (member in team) {
+        for (login in member$logins) {
+          user_repos <-
+            private$pull_repos(from = "user",
+                               user = login)
+          repos_from_team <-
+            append(repos_from_team, user_repos)
+        }
       }
       return(repos_from_team)
     },

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -195,6 +195,8 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
           break
         }
       }
+      full_repos_list <- full_repos_list %>%
+        private$pull_repos_languages()
       return(full_repos_list)
     },
 
@@ -280,7 +282,7 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
           "created_at" = project$created_at,
           "last_push" = NULL,
           "last_activity_at" = project$last_activity_at,
-          "languages" = ifelse(length(project$languages) == 0, "", project$languages),
+          "languages" = paste0(project$languages, collapse = ", "),
           "issues_open" = project$issues_open,
           "issues_closed" = project$issues_closed,
           "contributors" = NULL,

--- a/devel/example_workflow.R
+++ b/devel/example_workflow.R
@@ -37,7 +37,8 @@ git_stats %>%
 # You can set your search preferences
 setup(git_stats,
       search_param = "team",
-      team_name = "RWD")
+      team_name = "RWD",
+      language = "R")
 
 # now pull repos by default by team
 get_repos(git_stats)

--- a/tests/testthat/test-03-EngineGraphQLGitHub.R
+++ b/tests/testthat/test-03-EngineGraphQLGitHub.R
@@ -130,6 +130,10 @@ test_that("`pull_repos()` from user prepares formatted list", {
       "contributors", "repo_url"
     )
   )
+  expect_gt(
+    length(gh_repos_from_user[[1]][["languages"]]$nodes),
+    0
+  )
   test_mocker$cache(gh_repos_from_user)
 })
 
@@ -144,6 +148,10 @@ test_that("`pull_repos_from_team()` works smoothly", {
       "last_activity_at", "languages", "issues_open", "issues_closed",
       "contributors", "repo_url"
     )
+  )
+  expect_gt(
+    length(gh_repos_from_team[[1]][["languages"]]$nodes),
+    0
   )
   test_mocker$cache(gh_repos_from_team)
 })
@@ -196,6 +204,12 @@ test_that("`prepare_repos_table()` prepares repos table", {
     gh_repos_table
   )
   test_mocker$cache(gh_repos_table)
+  gh_repos_table_team <- test_gql_gh$prepare_repos_table(
+    repos_list = test_mocker$use("gh_repos_from_team")
+  )
+  expect_repos_table(
+    gh_repos_table_team
+  )
 })
 
 test_that("`prepare_commits_table()` prepares commits table", {


### PR DESCRIPTION
For GitLab problem was absence of language column: add language properly to GitLab when pulling repos by org or team (it did not work!). For GitHub problem was with wrong iteration for team: now it iterates over single logins.