### PR TITLE
258 let whole internal git platform be scanned

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 GitStats 0.1.0.9000
 
 - added setting tokens by default - if a user does have all the PATs set up in environment variables (as e.g. `GITHUB_PAT` or `GITLAB_PAT`), there is no need to pass them as an arugment to `set_connection` (I: #120 PR: #268),
-- added `get_users()` function to pull information on users (I: #199 PR: #238)
+- added `get_users()` function to pull information on users (I: #199 PR: #238),
+- added scanning whole internal git platforms (I: #258),
 - added switching to REST engine in case GraphQL fails with 502 error (I: #225 PRs: #227 (for repos) #261 (for commits))
 - added GraphQL engine for getting GitLab repos by organization (I: #218 PR: #233)
 - removed `contributors` as basic stat when pulling `repos` by `org` and by `phrase` to improve speed of pulling repositories data. Added `add_repos_contributors()` user function and `add_contributors` parameter to `get_repos()` function to add conditionally information on contributors to repositories table (I: #235 PRs: #243 #264)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@ GitStats 0.1.0.9000
 
 - added setting tokens by default - if a user does have all the PATs set up in environment variables (as e.g. `GITHUB_PAT` or `GITLAB_PAT`), there is no need to pass them as an arugment to `set_connection` (I: #120 PR: #268),
 - added `get_users()` function to pull information on users (I: #199 PR: #238),
-- added scanning whole internal git platforms (I: #258),
+- added possibility of scanning whole internal git platforms if no `orgs` are passed (I: #258),
 - added switching to REST engine in case GraphQL fails with 502 error (I: #225 PRs: #227 (for repos) #261 (for commits))
 - added GraphQL engine for getting GitLab repos by organization (I: #218 PR: #233)
 - removed `contributors` as basic stat when pulling `repos` by `org` and by `phrase` to improve speed of pulling repositories data. Added `add_repos_contributors()` user function and `add_contributors` parameter to `get_repos()` function to add conditionally information on contributors to repositories table (I: #235 PRs: #243 #264)

--- a/R/EngineGraphQL.R
+++ b/R/EngineGraphQL.R
@@ -15,13 +15,13 @@ EngineGraphQL <- R6::R6Class("EngineGraphQL",
      #' @description Create `EngineGraphQL` object.
      #' @param gql_api_url GraphQL API url.
      #' @param token A token.
-     #' @param scan_whole_host A boolean.
+     #' @param scan_all A boolean.
      initialize = function(gql_api_url,
                            token,
-                           scan_whole_host) {
+                           scan_all) {
        self$gql_api_url <- gql_api_url
        private$token <- token
-       private$scan_whole_host <- scan_whole_host
+       private$scan_all <- scan_all
      },
 
      #' @description Wrapper of GraphQL API request and response.
@@ -53,7 +53,7 @@ EngineGraphQL <- R6::R6Class("EngineGraphQL",
      token = NULL,
 
      # @field A boolean.
-     scan_whole_host = FALSE,
+     scan_all = FALSE,
 
      # @description A method to pull information on user.
      # @param username A login.

--- a/R/EngineGraphQL.R
+++ b/R/EngineGraphQL.R
@@ -15,10 +15,13 @@ EngineGraphQL <- R6::R6Class("EngineGraphQL",
      #' @description Create `EngineGraphQL` object.
      #' @param gql_api_url GraphQL API url.
      #' @param token A token.
+     #' @param scan_whole_host A boolean.
      initialize = function(gql_api_url,
-                           token) {
+                           token,
+                           scan_whole_host) {
        self$gql_api_url <- gql_api_url
        private$token <- token
+       private$scan_whole_host <- scan_whole_host
      },
 
      #' @description Wrapper of GraphQL API request and response.
@@ -48,6 +51,9 @@ EngineGraphQL <- R6::R6Class("EngineGraphQL",
    private = list(
      # @field token A token authorizing access to API.
      token = NULL,
+
+     # @field A boolean.
+     scan_whole_host = FALSE,
 
      # @description A method to pull information on user.
      # @param username A login.

--- a/R/EngineGraphQL.R
+++ b/R/EngineGraphQL.R
@@ -16,9 +16,9 @@ EngineGraphQL <- R6::R6Class("EngineGraphQL",
      #' @param gql_api_url GraphQL API url.
      #' @param token A token.
      #' @param scan_all A boolean.
-     initialize = function(gql_api_url,
-                           token,
-                           scan_all) {
+     initialize = function(gql_api_url = NA,
+                           token = NA,
+                           scan_all = FALSE) {
        self$gql_api_url <- gql_api_url
        private$token <- token
        private$scan_all <- scan_all

--- a/R/EngineGraphQLGitHub.R
+++ b/R/EngineGraphQLGitHub.R
@@ -10,10 +10,13 @@ EngineGraphQLGitHub <- R6::R6Class("EngineGraphQLGitHub",
     #' @description Create `EngineGraphQLGitHub` object.
     #' @param gql_api_url GraphQL API url.
     #' @param token A token.
+    #' @param scan_whole_host A boolean.
     initialize = function(gql_api_url,
-                          token) {
+                          token,
+                          scan_whole_host) {
       super$initialize(gql_api_url = gql_api_url,
-                       token = token)
+                       token = token,
+                       scan_whole_host = scan_whole_host)
       self$gql_query <- GQLQueryGitHub$new()
     },
 

--- a/R/EngineGraphQLGitHub.R
+++ b/R/EngineGraphQLGitHub.R
@@ -106,7 +106,9 @@ EngineGraphQLGitHub <- R6::R6Class("EngineGraphQLGitHub",
       repos_names <- repos_table$name
 
       if (settings$search_param == "org") {
-        cli::cli_alert_info("[GitHub][Engine:{cli::col_yellow('GraphQL')}][org:{org}] Pulling commits...")
+        if (!private$scan_all) {
+          cli::cli_alert_info("[GitHub][Engine:{cli::col_yellow('GraphQL')}][org:{org}] Pulling commits...")
+        }
         repos_list_with_commits <- private$pull_commits_from_repos(
           org = org,
           repos = repos_names,
@@ -115,7 +117,9 @@ EngineGraphQLGitHub <- R6::R6Class("EngineGraphQLGitHub",
         )
       }
       if (settings$search_param == "team") {
-        cli::cli_alert_info("[GitHub][Engine:{cli::col_yellow('GraphQL')}][org:{org}][team:{settings$team_name}] Pulling commits...")
+        if (!private$scan_all) {
+          cli::cli_alert_info("[GitHub][Engine:{cli::col_yellow('GraphQL')}][org:{org}][team:{settings$team_name}] Pulling commits...")
+        }
         repos_list_with_commits <- private$pull_commits_from_repos(
           org = org,
           repos = repos_names,
@@ -302,7 +306,7 @@ EngineGraphQLGitHub <- R6::R6Class("EngineGraphQLGitHub",
           }
           return(full_commits_list)
         }
-      }, .progress = TRUE)
+      }, .progress = !private$scan_all)
       return(repos_list_with_commits)
     },
 

--- a/R/EngineGraphQLGitHub.R
+++ b/R/EngineGraphQLGitHub.R
@@ -13,7 +13,7 @@ EngineGraphQLGitHub <- R6::R6Class("EngineGraphQLGitHub",
     #' @param scan_all A boolean.
     initialize = function(gql_api_url,
                           token,
-                          scan_all) {
+                          scan_all = FALSE) {
       super$initialize(gql_api_url = gql_api_url,
                        token = token,
                        scan_all = scan_all)

--- a/R/EngineGraphQLGitLab.R
+++ b/R/EngineGraphQLGitLab.R
@@ -12,7 +12,7 @@ EngineGraphQLGitLab <- R6::R6Class("EngineGraphQLGitLab",
      #' @param scan_all A boolean.
      initialize = function(gql_api_url,
                            token,
-                           scan_all) {
+                           scan_all = FALSE) {
        super$initialize(gql_api_url = gql_api_url,
                         token = token,
                         scan_all = scan_all)

--- a/R/EngineGraphQLGitLab.R
+++ b/R/EngineGraphQLGitLab.R
@@ -9,13 +9,13 @@ EngineGraphQLGitLab <- R6::R6Class("EngineGraphQLGitLab",
      #' @description Create `EngineGraphQLGitLab` object.
      #' @param gql_api_url GraphQL API url.
      #' @param token A token.
-     #' @param scan_whole_host A boolean.
+     #' @param scan_all A boolean.
      initialize = function(gql_api_url,
                            token,
-                           scan_whole_host) {
+                           scan_all) {
        super$initialize(gql_api_url = gql_api_url,
                         token = token,
-                        scan_whole_host = scan_whole_host)
+                        scan_all = scan_all)
        self$gql_query <- GQLQueryGitLab$new()
      },
 
@@ -24,7 +24,6 @@ EngineGraphQLGitLab <- R6::R6Class("EngineGraphQLGitLab",
        group_cursor <- ""
        has_next_page <- TRUE
        full_orgs_list <- list()
-       i <- 1
        while(has_next_page) {
          response <- self$gql_response(
            gql_query = self$gql_query$groups(),
@@ -47,7 +46,7 @@ EngineGraphQLGitLab <- R6::R6Class("EngineGraphQLGitLab",
      get_repos = function(org,
                           settings) {
        if (settings$search_param == "org") {
-         if (!private$scan_whole_host) {
+         if (!private$scan_all) {
            cli::cli_alert_info("[GitLab][Engine:{cli::col_yellow('GraphQL')}][org:{org}] Pulling repositories...")
          }
          repos_table <- private$pull_repos(

--- a/R/EngineGraphQLGitLab.R
+++ b/R/EngineGraphQLGitLab.R
@@ -9,11 +9,34 @@ EngineGraphQLGitLab <- R6::R6Class("EngineGraphQLGitLab",
      #' @description Create `EngineGraphQLGitLab` object.
      #' @param gql_api_url GraphQL API url.
      #' @param token A token.
+     #' @param scan_whole_host A boolean.
      initialize = function(gql_api_url,
-                           token) {
+                           token,
+                           scan_whole_host) {
        super$initialize(gql_api_url = gql_api_url,
-                        token = token)
+                        token = token,
+                        scan_whole_host = scan_whole_host)
        self$gql_query <- GQLQueryGitLab$new()
+     },
+
+     #' @description Get all groups from GitLab.
+     get_orgs = function() {
+       group_cursor <- ""
+       has_next_page <- TRUE
+       full_orgs_list <- list()
+       i <- 1
+       while(has_next_page) {
+         response <- self$gql_response(
+           gql_query = self$gql_query$groups(),
+           vars = list("groupCursor" = group_cursor)
+         )
+         orgs_list <- purrr::map(response$data$groups$edges, ~.$node$fullPath)
+         full_orgs_list <- append(full_orgs_list, orgs_list)
+         has_next_page <- response$data$groups$pageInfo$hasNextPage
+         group_cursor <- response$data$groups$pageInfo$endCursor
+       }
+       all_orgs <- unlist(full_orgs_list)
+       return(all_orgs)
      },
 
      #' @description A method to retrieve all repositories for an organization in
@@ -24,7 +47,9 @@ EngineGraphQLGitLab <- R6::R6Class("EngineGraphQLGitLab",
      get_repos = function(org,
                           settings) {
        if (settings$search_param == "org") {
-         cli::cli_alert_info("[GitLab][Engine:{cli::col_yellow('GraphQL')}][org:{org}] Pulling repositories...")
+         if (!private$scan_whole_host) {
+           cli::cli_alert_info("[GitLab][Engine:{cli::col_yellow('GraphQL')}][org:{org}] Pulling repositories...")
+         }
          repos_table <- private$pull_repos(
            from = "org",
            org = org

--- a/R/EngineRest.R
+++ b/R/EngineRest.R
@@ -13,14 +13,14 @@ EngineRest <- R6::R6Class("EngineRest",
     #' @description Create a new `Rest` object
     #' @param rest_api_url A character, url of Rest API.
     #' @param token A token.
-    #' @param scan_whole_host A boolean.
+    #' @param scan_all A boolean.
     #' @return A `Rest` object.
     initialize = function(rest_api_url = NA,
                           token = NA,
-                          scan_whole_host) {
+                          scan_all) {
       self$rest_api_url <- rest_api_url
       private$token <- token
-      private$scan_whole_host <- scan_whole_host
+      private$scan_all <- scan_all
     },
 
     #' @description A wrapper for httr2 functions to perform get request to REST API endpoints.
@@ -45,7 +45,7 @@ EngineRest <- R6::R6Class("EngineRest",
     token = NULL,
 
     # @field A boolean.
-    scan_whole_host = FALSE,
+    scan_all = FALSE,
 
     # @description Check whether the token exists.
     # @param token A token.
@@ -97,7 +97,7 @@ EngineRest <- R6::R6Class("EngineRest",
         },
         error = function(e) {
           if (!is.null(e$status)) {
-            if (!private$scan_whole_host) {
+            if (!private$scan_all) {
               if (e$status == 400) {
                 message("HTTP 400 Bad Request.")
               } else if (e$status == 401) {

--- a/R/EngineRest.R
+++ b/R/EngineRest.R
@@ -13,11 +13,14 @@ EngineRest <- R6::R6Class("EngineRest",
     #' @description Create a new `Rest` object
     #' @param rest_api_url A character, url of Rest API.
     #' @param token A token.
+    #' @param scan_whole_host A boolean.
     #' @return A `Rest` object.
     initialize = function(rest_api_url = NA,
-                          token = NA) {
+                          token = NA,
+                          scan_whole_host) {
       self$rest_api_url <- rest_api_url
       private$token <- token
+      private$scan_whole_host <- scan_whole_host
     },
 
     #' @description A wrapper for httr2 functions to perform get request to REST API endpoints.
@@ -40,6 +43,9 @@ EngineRest <- R6::R6Class("EngineRest",
 
     # @field token A token authorizing access to API.
     token = NULL,
+
+    # @field A boolean.
+    scan_whole_host = FALSE,
 
     # @description Check whether the token exists.
     # @param token A token.
@@ -91,14 +97,16 @@ EngineRest <- R6::R6Class("EngineRest",
         },
         error = function(e) {
           if (!is.null(e$status)) {
-            if (e$status == 400) {
-              message("HTTP 400 Bad Request.")
-            } else if (e$status == 401) {
-              message("HTTP 401 Unauthorized.")
-            } else if (e$status == 403) {
-              message("HTTP 403 API limit reached.")
-            } else if (e$status == 404) {
-              message("HTTP 404 No such address")
+            if (!private$scan_whole_host) {
+              if (e$status == 400) {
+                message("HTTP 400 Bad Request.")
+              } else if (e$status == 401) {
+                message("HTTP 401 Unauthorized.")
+              } else if (e$status == 403) {
+                message("HTTP 403 API limit reached.")
+              } else if (e$status == 404) {
+                message("HTTP 404 No such address")
+              }
             }
           } else if (grepl("Could not resolve host", e)) {
             cli::cli_abort(c(

--- a/R/EngineRestGitHub.R
+++ b/R/EngineRestGitHub.R
@@ -53,7 +53,9 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
     get_repos = function(org,
                          settings) {
       if (settings$search_param == "phrase") {
-        cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][phrase:{settings$phrase}][org:{org}] Searching repositories...")
+        if (!private$scan_all) {
+          cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][phrase:{settings$phrase}][org:{org}] Searching repositories...")
+        }
         repos_table <- private$search_repos_by_phrase(
           org = org,
           phrase = settings$phrase,

--- a/R/EngineRestGitHub.R
+++ b/R/EngineRestGitHub.R
@@ -4,48 +4,6 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
   inherit = EngineRest,
   public = list(
 
-    #' @description Create new `EngineRestGitHub` object.
-    #' @param rest_api_url A REST API url.
-    #' @param token A token.
-    #' @param scan_all A boolean.
-    initialize = function(rest_api_url,
-                          token,
-                          scan_all) {
-      super$initialize(
-        rest_api_url = rest_api_url,
-        token = private$check_token(token),
-        scan_all = scan_all
-      )
-    },
-
-    #' @description Check if an organization exists
-    #' @param orgs A character vector of organizations
-    #' @return orgs or NULL.
-    check_organizations = function(orgs) {
-      orgs <- purrr::map(orgs, function(org) {
-        org_endpoint <- "/orgs/"
-        withCallingHandlers(
-          {
-            self$response(endpoint = paste0(self$rest_api_url, org_endpoint, org))
-          },
-          message = function(m) {
-            if (grepl("40", m)) {
-              cli::cli_abort("Improper name of organization.")
-              org <<- NULL
-            }
-          }
-        )
-        return(org)
-      }) %>%
-        purrr::keep(~ length(.) > 0) %>%
-        unlist()
-
-      if (length(orgs) == 0) {
-        return(NULL)
-      }
-      orgs
-    },
-
     #' @description Method to get repositories with phrase in code blobs.
     #' @param org An organization
     #' @param settings A list of  `GitStats` settings.

--- a/R/EngineRestGitHub.R
+++ b/R/EngineRestGitHub.R
@@ -7,11 +7,14 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
     #' @description Create new `EngineRestGitHub` object.
     #' @param rest_api_url A REST API url.
     #' @param token A token.
+    #' @param scan_whole_host A boolean.
     initialize = function(rest_api_url,
-                          token) {
+                          token,
+                          scan_whole_host) {
       super$initialize(
         rest_api_url = rest_api_url,
-        token = private$check_token(token)
+        token = private$check_token(token),
+        scan_whole_host = scan_whole_host
       )
     },
 
@@ -73,7 +76,9 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
     get_repos_supportive = function(org,
                                     settings) {
       if (settings$search_param %in% c("org")) {
-        cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][org:{org}] Pulling repositories...")
+        if (!private$scan_whole_host) {
+          cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][org:{org}] Pulling repositories...")
+        }
         repos_table <- private$pull_repos_from_org(
           org = org
         ) %>%

--- a/R/EngineRestGitHub.R
+++ b/R/EngineRestGitHub.R
@@ -122,10 +122,12 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
         org = org,
         settings = list(search_param = "org")
       )
-      if (settings$search_param == "org") {
-        cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][org:{org}] Pulling commits...")
-      } else if (settings$search_param == "team") {
-        cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][org:{org}][team:{settings$team_name}] Pulling commits...")
+      if (!private$scan_all) {
+        if (settings$search_param == "org") {
+          cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][org:{org}] Pulling commits...")
+        } else if (settings$search_param == "team") {
+          cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}][org:{org}][team:{settings$team_name}] Pulling commits...")
+        }
       }
       repos_list_with_commits <- private$pull_commits_from_org(
         repos_table = repos_table,
@@ -152,7 +154,9 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
     #' @return A table of repositories with added information on contributors.
     add_repos_contributors = function(repos_table) {
       if (nrow(repos_table) > 0) {
-        cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}] Pulling contributors...")
+        if (!private$scan_all) {
+          cli::cli_alert_info("[GitHub][Engine:{cli::col_green('REST')}] Pulling contributors...")
+        }
         repo_iterator <- paste0(repos_table$organization, "/", repos_table$name)
         user_name <- rlang::expr(.$login)
         repos_table$contributors <- purrr::map_chr(repo_iterator, function(repos_id) {

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -7,14 +7,14 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     #' @description Create new `EngineRestGitLab` object.
     #' @param rest_api_url A REST API url.
     #' @param token A token.
-    #' @param scan_whole_host A boolean.
+    #' @param scan_all A boolean.
     initialize = function(rest_api_url,
                           token,
-                          scan_whole_host) {
+                          scan_all) {
       super$initialize(
         rest_api_url = rest_api_url,
         token = private$check_token(token),
-        scan_whole_host = scan_whole_host
+        scan_all = scan_all
       )
     },
 
@@ -56,7 +56,7 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     get_repos = function(org,
                          settings) {
       if (settings$search_param == "phrase") {
-        if (!private$scan_whole_host) {
+        if (!private$scan_all) {
           cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][phrase:{settings$phrase}][org:{org}] Searching repositories...")
         }
         repos_table <- private$search_repos_by_phrase(
@@ -68,7 +68,7 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
           private$prepare_repos_table() %>%
           private$add_repos_issues()
       } else if (settings$search_param == "team") {
-        if (!private$scan_whole_host) {
+        if (!private$scan_all) {
           cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}][team:{settings$team_name}] Pulling repositories...")
         }
         org <- private$get_group_id(org)
@@ -94,8 +94,9 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     #' @return Nothing.
     get_repos_supportive = function(org,
                                     settings) {
+      repos_table <- NULL
       if (settings$search_param == "org") {
-        if (!private$scan_whole_host) {
+        if (!private$scan_all) {
           cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}] Pulling repositories...")
         }
         org <- private$get_group_id(org)

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -4,50 +4,6 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
   inherit = EngineRest,
   public = list(
 
-    #' @description Create new `EngineRestGitLab` object.
-    #' @param rest_api_url A REST API url.
-    #' @param token A token.
-    #' @param scan_all A boolean.
-    initialize = function(rest_api_url,
-                          token,
-                          scan_all) {
-      super$initialize(
-        rest_api_url = rest_api_url,
-        token = private$check_token(token),
-        scan_all = scan_all
-      )
-    },
-
-    #' @description Check if an organization exists
-    #' @param orgs A character vector of organizations
-    #' @return orgs or NULL.
-    check_organizations = function(orgs) {
-      orgs <- purrr::map(orgs, function(org) {
-        org_endpoint <- "/groups/"
-        withCallingHandlers(
-          {
-            self$response(endpoint = paste0(self$rest_api_url, org_endpoint, org))
-          },
-          message = function(m) {
-            if (grepl("404", m)) {
-              cli::cli_alert_danger("Group name passed in a wrong way: {org}")
-              cli::cli_alert_warning("If you are using `GitLab`, please type your group name as you see it in `url`.")
-              cli::cli_alert_info("E.g. do not use spaces. Group names as you see on the page may differ from their 'address' name.")
-              org <<- NULL
-            }
-          }
-        )
-        return(org)
-      }) %>%
-        purrr::keep(~ length(.) > 0) %>%
-        unlist()
-
-      if (length(orgs) == 0) {
-        return(NULL)
-      }
-      orgs
-    },
-
     #' @description A method to retrieve all repositories for an organization in
     #'   a table format.
     #' @param org A character, a group of projects.

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -7,11 +7,14 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     #' @description Create new `EngineRestGitLab` object.
     #' @param rest_api_url A REST API url.
     #' @param token A token.
+    #' @param scan_whole_host A boolean.
     initialize = function(rest_api_url,
-                          token) {
+                          token,
+                          scan_whole_host) {
       super$initialize(
         rest_api_url = rest_api_url,
-        token = private$check_token(token)
+        token = private$check_token(token),
+        scan_whole_host = scan_whole_host
       )
     },
 
@@ -53,7 +56,9 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     get_repos = function(org,
                          settings) {
       if (settings$search_param == "phrase") {
-        cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][phrase:{settings$phrase}][org:{org}] Searching repositories...")
+        if (!private$scan_whole_host) {
+          cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][phrase:{settings$phrase}][org:{org}] Searching repositories...")
+        }
         repos_table <- private$search_repos_by_phrase(
           org = org,
           phrase = settings$phrase,
@@ -63,7 +68,9 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
           private$prepare_repos_table() %>%
           private$add_repos_issues()
       } else if (settings$search_param == "team") {
-        cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}][team:{settings$team_name}] Pulling repositories...")
+        if (!private$scan_whole_host) {
+          cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}][team:{settings$team_name}] Pulling repositories...")
+        }
         org <- private$get_group_id(org)
         repos_table <- private$pull_repos_from_org(org) %>%
           private$tailor_repos_info() %>%
@@ -88,7 +95,9 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     get_repos_supportive = function(org,
                                     settings) {
       if (settings$search_param == "org") {
-        cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}] Pulling repositories...")
+        if (!private$scan_whole_host) {
+          cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}] Pulling repositories...")
+        }
         org <- private$get_group_id(org)
         repos_table <- private$pull_repos_from_org(org) %>%
           private$tailor_repos_info() %>%

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -113,7 +113,9 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     #' @return A table of repositories with added information on contributors.
     add_repos_contributors = function(repos_table) {
       if (nrow(repos_table) > 0) {
-        cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}] Pulling contributors...")
+        if (!private$scan_all) {
+          cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}] Pulling contributors...")
+        }
         repo_iterator <- repos_table$id
         user_name <- rlang::expr(.$name)
         repos_table$contributors <- purrr::map_chr(repo_iterator, function(repos_id) {
@@ -151,13 +153,13 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
         org = org,
         settings = list(search_param = "org")
       )
-
-      if (settings$search_param == "org") {
-        cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}] Pulling commits...")
-      } else if (settings$search_param == "team") {
-        cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}][team:{settings$team_name}] Pulling commits...")
+      if (!private$scan_all) {
+        if (settings$search_param == "org") {
+          cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}] Pulling commits...")
+        } else if (settings$search_param == "team") {
+          cli::cli_alert_info("[GitLab][Engine:{cli::col_green('REST')}][org:{org}][team:{settings$team_name}] Pulling commits...")
+        }
       }
-
       repos_list_with_commits <- private$pull_commits_from_org(
         repos_table = repos_table,
         date_from = date_from,
@@ -374,7 +376,7 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
           date_until = date_until
         )
         return(commits_from_repo)
-      }, .progress = TRUE)
+      }, .progress = !private$scan_all)
       names(repos_list_with_commits) <- repos_names
       return(repos_list_with_commits)
     },

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -198,12 +198,15 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
       page <- 1
       still_more_hits <- TRUE
       resp_list <- list()
-      groups_id <- private$get_group_id(org)
-
+      groups_url <- if (!private$scan_all) {
+        paste0("/groups/", private$get_group_id(org))
+      } else {
+        ""
+      }
       while (still_more_hits | page < page_max) {
         resp <- self$response(
           paste0(
-            self$rest_api_url, "/groups/", groups_id,
+            self$rest_api_url, groups_url,
             "/search?scope=blobs&search=", phrase, "&per_page=100&page=", page
           )
         )

--- a/R/GQLQueryGitHub.R
+++ b/R/GQLQueryGitHub.R
@@ -4,6 +4,35 @@
 GQLQueryGitHub <- R6::R6Class("GQLQueryGitHub",
   public = list(
 
+    #' @description Prepare query to list organizations from GitHub.
+    #' @param end_cursor An end cursor to paginate.
+    #' @return A query.
+    orgs = function(end_cursor) {
+      if (is.null(end_cursor)) {
+        pagination_phrase <- ''
+      } else {
+        pagination_phrase <- paste0('after: "', end_cursor, '"')
+      }
+
+      paste0(
+      'query {
+        search(first: 100, type: USER, query: "type:org" ', pagination_phrase, ') {
+          pageInfo {
+             hasNextPage
+             endCursor
+          }
+          edges {
+            node{
+              ... on Organization {
+                name
+                url
+              }
+            }
+          }
+        }
+      }')
+    },
+
     #' @description Prepare query to get repositories from GitHub.
     #' @param org An organization of repositories.
     #' @param repo_cursor An end cursor for repositories page.

--- a/R/GQLQueryGitLab.R
+++ b/R/GQLQueryGitLab.R
@@ -4,6 +4,24 @@
 GQLQueryGitLab <- R6::R6Class("GQLQueryGitLab",
   public = list(
 
+    #' @description Prepare query to list groups from GitLab.
+    #' @return A query.
+    groups = function() {
+      'query GetGroups($groupCursor: String!) {
+            groups (after: $groupCursor) {
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
+              edges {
+                node {
+                  fullPath
+                }
+              }
+            }
+        }'
+    },
+
     #' @description Prepare query to get repositories from GitLab.
     #' @param repo_cursor An end cursor for repositories page.
     #' @return A query.

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -18,16 +18,21 @@ GitHost <- R6::R6Class("GitHost",
                           token = NA,
                           api_url = NA) {
       private$api_url <- api_url
-      private$is_public <- private$check_if_public(api_url)
-      private$host <- private$set_host(api_url)
+      private$is_public <- private$check_if_public()
+      private$host <- private$set_host()
       if (is.null(token)){
         private$token <- private$set_default_token()
+      } else {
+        private$token <- token
       }
       if (is.null(orgs)) {
         if (private$is_public) {
-          cli::cli_abort(
-            "You need to specify `orgs` for public Git platform."
-          )
+          cli::cli_abort(c(
+            "You need to specify `orgs` for public Git Host.",
+            "x" = "Host will not be added.",
+            "i" = "Add organizations to your `orgs` parameter."
+          ),
+          call = NULL)
         } else {
           cli::cli_alert_warning(cli::col_yellow(
             "No `orgs` specified. I will pull all organizations from the Git Host."
@@ -185,8 +190,8 @@ GitHost <- R6::R6Class("GitHost",
     engines = list(),
 
     # @description Check whether Git platform is public or internal.
-    check_if_public = function(api_url) {
-      if (grepl("api.github.com|gitlab.com/api", api_url)) {
+    check_if_public = function() {
+      if (grepl("api.github.com|gitlab.com/api", private$api_url)) {
         TRUE
       } else {
         FALSE
@@ -194,13 +199,18 @@ GitHost <- R6::R6Class("GitHost",
     },
 
     # @description Set name of a Git Host.
-    set_host = function(api_url) {
+    set_host = function() {
       if (grepl("https://", private$api_url) && grepl("github", private$api_url)) {
         "GitHub"
       } else if (grepl("https://", private$api_url) && grepl("gitlab|code", private$api_url)) {
         "GitLab"
       } else {
-        stop("This connection is not supported by GitStats class object.")
+        cli::cli_abort(c(
+          "This connection is not supported by GitStats class object.",
+          "x" = "Host will not be added."
+          ),
+          call = NULL
+        )
       }
     },
 

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -105,7 +105,9 @@ GitHost <- R6::R6Class("GitHost",
           "i" = "Please change your `search_param` either to 'org' or 'team' with `setup()`."
         ))
       }
-
+      if (private$scan_all) {
+        cli::cli_alert_info("[Host:{private$host}] {cli::col_yellow('Pulling commits from all organizations...')}")
+      }
       commits_table <- purrr::map(private$orgs, function(org) {
         tryCatch({
           commits_table_org <- purrr::map(private$engines, ~ .$get_commits(
@@ -138,7 +140,7 @@ GitHost <- R6::R6Class("GitHost",
         })
 
         return(commits_table_org)
-      }) %>%
+      }, .progress = private$scan_all) %>%
         purrr::list_rbind()
 
       return(commits_table)
@@ -287,6 +289,9 @@ GitHost <- R6::R6Class("GitHost",
 
     # @description Pull repositories from organisations.
     pull_repos_from_orgs = function(settings) {
+      if (private$scan_all) {
+        cli::cli_alert_info("[Host:{private$host}] {cli::col_yellow('Pulling repositories from all organizations...')}")
+      }
       repos_table <- purrr::map(private$orgs, function(org) {
         tryCatch({
           repos_list <- purrr::map(private$engines, function (engine) {

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -299,10 +299,14 @@ GitHost <- R6::R6Class("GitHost",
 
     # @description Pull repositories from organisations.
     pull_repos_from_orgs = function(settings) {
+      orgs <- private$orgs
       if (private$scan_all) {
         cli::cli_alert_info("[Host:{private$host}] {cli::col_yellow('Pulling repositories from all organizations...')}")
+        if (settings$search_param == "phrase") {
+          orgs <- "no_orgs"
+        }
       }
-      repos_table <- purrr::map(private$orgs, function(org) {
+      repos_table <- purrr::map(orgs, function(org) {
         tryCatch({
           repos_list <- purrr::map(private$engines, function (engine) {
             engine$get_repos(

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -95,7 +95,7 @@ GitStats <- R6::R6Class("GitStats",
         }
       },
       error = function(e){
-        cli::cli_alert_warning(e$message)
+        print(e)
         cli::cli_alert_danger("Host will not be passed.")
       })
       if (!is.null(new_host)) {

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -82,27 +82,23 @@ GitStats <- R6::R6Class("GitStats",
                         token,
                         orgs) {
       new_host <- NULL
-      tryCatch({
-        new_host <- GitHost$new(
-          orgs = orgs,
-          token = token,
-          api_url = api_url
-        )
-        if  (grepl("https://", api_url) && grepl("github", api_url)) {
-          cli::cli_alert_success("Set connection to GitHub.")
-        } else if (grepl("https://", api_url) && grepl("gitlab|code", api_url)) {
-          cli::cli_alert_success("Set connection to GitLab.")
-        }
-      },
-      error = function(e){
-        print(e)
-        cli::cli_alert_danger("Host will not be passed.")
-      })
-      if (!is.null(new_host)) {
-        private$hosts <- new_host %>%
-          private$check_for_duplicate_hosts() %>%
-          append(private$hosts, .)
+
+      new_host <- GitHost$new(
+        orgs = orgs,
+        token = token,
+        api_url = api_url
+      )
+      if  (grepl("https://", api_url) && grepl("github", api_url)) {
+        cli::cli_alert_success("Set connection to GitHub.")
+      } else if (grepl("https://", api_url) && grepl("gitlab|code", api_url)) {
+        cli::cli_alert_success("Set connection to GitLab.")
       }
+
+    if (!is.null(new_host)) {
+      private$hosts <- new_host %>%
+        private$check_for_duplicate_hosts() %>%
+        append(private$hosts, .)
+    }
     },
 
     #' @description A method to add a team member.

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -242,8 +242,7 @@ GitStats <- R6::R6Class("GitStats",
       orgs <- purrr::map(private$hosts, function(host) {
         host_priv <- environment(host$initialize)$private
         orgs <- host_priv$orgs
-        paste0(orgs, collapse = ", ")
-      }) %>% paste0(collapse = ", ")
+      })
       private$print_item("Organisations", orgs)
       private$print_item("Search preference", private$settings$search_param)
       private$print_item("Team", private$settings$team_name, paste0(private$settings$team_name, " (", length(private$settings$team), " members)"))
@@ -329,6 +328,18 @@ GitStats <- R6::R6Class("GitStats",
     print_item = function(item_name,
                           item_to_check,
                           item_to_print = item_to_check) {
+      if (item_name == "Organisations") {
+        item_to_print <- unlist(item_to_print)
+        if (length(item_to_print) < 10) {
+          list_items <- paste0(item_to_print, collapse = ", ")
+
+        } else {
+          item_to_print_cut <- item_to_print[1:10]
+          list_items <- paste0(item_to_print_cut, collapse = ", ") %>%
+            paste0("... and ", length(item_to_print) - 10, " more")
+        }
+        item_to_print <- paste0("[", cli::col_green(length(item_to_print)), "] ", list_items)
+      }
       cat(paste0(
         cli::col_blue(paste0(item_name, ": ")),
         ifelse(is.null(item_to_check),

--- a/R/gitstats_functions.R
+++ b/R/gitstats_functions.R
@@ -13,8 +13,12 @@ create_gitstats <- function() {
 #' @param gitstats_obj A GitStats object.
 #' @param api_url A character, url address of API.
 #' @param token A token.
-#' @param orgs A character vector of organisations (owners of repositories
-#'   in case of GitHub and groups of projects in case of GitLab).
+#' @param orgs A character vector of organisations (owners of repositories in
+#'   case of GitHub and groups of projects in case of GitLab). You do not need
+#'   to define `orgs` if you wish to scan whole internal Git platform (such as
+#'   enterprise version of GitHub or GitLab). In case of a public one (like
+#'   GitHub) you need to define `orgs` as scanning through all organizations
+#'   would be an overkill.
 #' @return A `GitStats` class object with added information on connection
 #'   (`$hosts` field).
 #' @examples
@@ -34,7 +38,7 @@ create_gitstats <- function() {
 set_connection <- function(gitstats_obj,
                            api_url,
                            token = NULL,
-                           orgs) {
+                           orgs = NULL) {
   gitstats_obj$add_host(
     api_url = api_url,
     token = token,

--- a/R/test_helpers.R
+++ b/R/test_helpers.R
@@ -29,6 +29,7 @@ TestHost <- R6::R6Class("TestHost",
                           token = NA,
                           api_url = NA) {
       private$api_url <- api_url
+      private$host <- private$set_host()
       if (grepl("https://", api_url) && grepl("github", api_url)) {
         private$engines$rest <- TestEngineRestGitHub$new(
           token = token,

--- a/R/test_helpers.R
+++ b/R/test_helpers.R
@@ -30,7 +30,7 @@ TestHost <- R6::R6Class("TestHost",
                           api_url = NA) {
       private$api_url <- api_url
       if (grepl("https://", api_url) && grepl("github", api_url)) {
-        private$engines$rest <- EngineRestGitHub$new(
+        private$engines$rest <- TestEngineRestGitHub$new(
           token = token,
           rest_api_url = api_url
         )
@@ -39,7 +39,7 @@ TestHost <- R6::R6Class("TestHost",
           gql_api_url = private$set_gql_url(api_url)
         )
       } else if (grepl("https://", api_url) && grepl("gitlab|code", api_url)) {
-        private$engines$rest <- EngineRestGitLab$new(
+        private$engines$rest <- TestEngineRest$new(
           token = token,
           rest_api_url = api_url
         )
@@ -81,6 +81,32 @@ TestEngineRest <- R6::R6Class("TestEngineRest",
       self$rest_api_url <- rest_api_url
     }
   )
+)
+
+#' @noRd
+#' @description A helper class to use in tests.
+TestEngineRestGitHub <- R6::R6Class("TestEngineRestGitHub",
+                              inherit = EngineRestGitHub,
+                              public = list(
+                                initialize = function(token,
+                                                      rest_api_url) {
+                                  private$token <- token
+                                  self$rest_api_url <- rest_api_url
+                                }
+                              )
+)
+
+#' @noRd
+#' @description A helper class to use in tests.
+TestEngineRestGitLab <- R6::R6Class("TestEngineRestGitLab",
+                                    inherit = EngineRestGitLab,
+                                    public = list(
+                                      initialize = function(token,
+                                                            rest_api_url) {
+                                        private$token <- token
+                                        self$rest_api_url <- rest_api_url
+                                      }
+                                    )
 )
 
 #' @noRd

--- a/man/EngineGraphQL.Rd
+++ b/man/EngineGraphQL.Rd
@@ -30,7 +30,7 @@ A class for methods wrapping GitHub's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQL} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQL$new(gql_api_url, token, scan_all)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQL$new(gql_api_url = NA, token = NA, scan_all = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/EngineGraphQL.Rd
+++ b/man/EngineGraphQL.Rd
@@ -30,7 +30,7 @@ A class for methods wrapping GitHub's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQL} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQL$new(gql_api_url, token)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQL$new(gql_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -39,6 +39,8 @@ Create \code{EngineGraphQL} object.
 \item{\code{gql_api_url}}{GraphQL API url.}
 
 \item{\code{token}}{A token.}
+
+\item{\code{scan_whole_host}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineGraphQL.Rd
+++ b/man/EngineGraphQL.Rd
@@ -30,7 +30,7 @@ A class for methods wrapping GitHub's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQL} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQL$new(gql_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQL$new(gql_api_url, token, scan_all)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -40,7 +40,7 @@ Create \code{EngineGraphQL} object.
 
 \item{\code{token}}{A token.}
 
-\item{\code{scan_whole_host}}{A boolean.}
+\item{\code{scan_all}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineGraphQLGitHub.Rd
+++ b/man/EngineGraphQLGitHub.Rd
@@ -13,6 +13,7 @@ A class for methods wrapping GitHub's GraphQL API responses.
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{EngineGraphQLGitHub$new()}}
+\item \href{#method-get_orgs}{\code{EngineGraphQLGitHub$get_orgs()}}
 \item \href{#method-get_repos}{\code{EngineGraphQLGitHub$get_repos()}}
 \item \href{#method-get_repos_supportive}{\code{EngineGraphQLGitHub$get_repos_supportive()}}
 \item \href{#method-get_commits}{\code{EngineGraphQLGitHub$get_commits()}}
@@ -34,7 +35,7 @@ A class for methods wrapping GitHub's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQLGitHub} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitHub$new(gql_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitHub$new(gql_api_url, token, scan_all)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -44,10 +45,20 @@ Create \code{EngineGraphQLGitHub} object.
 
 \item{\code{token}}{A token.}
 
-\item{\code{scan_whole_host}}{A boolean.}
+\item{\code{scan_all}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_orgs"></a>}}
+\if{latex}{\out{\hypertarget{method-get_orgs}{}}}
+\subsection{Method \code{get_orgs()}}{
+Get all groups from GitLab.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitHub$get_orgs()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-get_repos"></a>}}

--- a/man/EngineGraphQLGitHub.Rd
+++ b/man/EngineGraphQLGitHub.Rd
@@ -35,7 +35,7 @@ A class for methods wrapping GitHub's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQLGitHub} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitHub$new(gql_api_url, token, scan_all)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitHub$new(gql_api_url, token, scan_all = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/EngineGraphQLGitHub.Rd
+++ b/man/EngineGraphQLGitHub.Rd
@@ -34,7 +34,7 @@ A class for methods wrapping GitHub's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQLGitHub} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitHub$new(gql_api_url, token)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitHub$new(gql_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -43,6 +43,8 @@ Create \code{EngineGraphQLGitHub} object.
 \item{\code{gql_api_url}}{GraphQL API url.}
 
 \item{\code{token}}{A token.}
+
+\item{\code{scan_whole_host}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineGraphQLGitLab.Rd
+++ b/man/EngineGraphQLGitLab.Rd
@@ -34,7 +34,7 @@ A class for methods wrapping GitLab's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQLGitLab} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitLab$new(gql_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitLab$new(gql_api_url, token, scan_all)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -44,7 +44,7 @@ Create \code{EngineGraphQLGitLab} object.
 
 \item{\code{token}}{A token.}
 
-\item{\code{scan_whole_host}}{A boolean.}
+\item{\code{scan_all}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineGraphQLGitLab.Rd
+++ b/man/EngineGraphQLGitLab.Rd
@@ -34,7 +34,7 @@ A class for methods wrapping GitLab's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQLGitLab} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitLab$new(gql_api_url, token, scan_all)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitLab$new(gql_api_url, token, scan_all = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/EngineGraphQLGitLab.Rd
+++ b/man/EngineGraphQLGitLab.Rd
@@ -13,6 +13,7 @@ A class for methods wrapping GitLab's GraphQL API responses.
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{EngineGraphQLGitLab$new()}}
+\item \href{#method-get_orgs}{\code{EngineGraphQLGitLab$get_orgs()}}
 \item \href{#method-get_repos}{\code{EngineGraphQLGitLab$get_repos()}}
 \item \href{#method-get_repos_supportive}{\code{EngineGraphQLGitLab$get_repos_supportive()}}
 \item \href{#method-get_commits}{\code{EngineGraphQLGitLab$get_commits()}}
@@ -33,7 +34,7 @@ A class for methods wrapping GitLab's GraphQL API responses.
 \subsection{Method \code{new()}}{
 Create \code{EngineGraphQLGitLab} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitLab$new(gql_api_url, token)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitLab$new(gql_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -42,9 +43,21 @@ Create \code{EngineGraphQLGitLab} object.
 \item{\code{gql_api_url}}{GraphQL API url.}
 
 \item{\code{token}}{A token.}
+
+\item{\code{scan_whole_host}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_orgs"></a>}}
+\if{latex}{\out{\hypertarget{method-get_orgs}{}}}
+\subsection{Method \code{get_orgs()}}{
+Get all groups from GitLab.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{EngineGraphQLGitLab$get_orgs()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-get_repos"></a>}}

--- a/man/EngineRest.Rd
+++ b/man/EngineRest.Rd
@@ -27,7 +27,7 @@ A superclass for methods wrapping Rest API responses.
 \subsection{Method \code{new()}}{
 Create a new \code{Rest} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRest$new(rest_api_url = NA, token = NA)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineRest$new(rest_api_url = NA, token = NA, scan_whole_host)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -36,6 +36,8 @@ Create a new \code{Rest} object
 \item{\code{rest_api_url}}{A character, url of Rest API.}
 
 \item{\code{token}}{A token.}
+
+\item{\code{scan_whole_host}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineRest.Rd
+++ b/man/EngineRest.Rd
@@ -18,6 +18,7 @@ A superclass for methods wrapping Rest API responses.
 \itemize{
 \item \href{#method-new}{\code{EngineRest$new()}}
 \item \href{#method-response}{\code{EngineRest$response()}}
+\item \href{#method-check_organizations}{\code{EngineRest$check_organizations()}}
 \item \href{#method-clone}{\code{EngineRest$clone()}}
 }
 }
@@ -27,7 +28,7 @@ A superclass for methods wrapping Rest API responses.
 \subsection{Method \code{new()}}{
 Create a new \code{Rest} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRest$new(rest_api_url = NA, token = NA, scan_all)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineRest$new(rest_api_url = NA, token = NA, scan_all = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -65,6 +66,26 @@ A wrapper for httr2 functions to perform get request to REST API endpoints.
 }
 \subsection{Returns}{
 A content of response formatted to list.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-check_organizations"></a>}}
+\if{latex}{\out{\hypertarget{method-check_organizations}{}}}
+\subsection{Method \code{check_organizations()}}{
+Check if an organization exists
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{EngineRest$check_organizations(orgs)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{orgs}}{A character vector of organizations}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+orgs or NULL.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/EngineRest.Rd
+++ b/man/EngineRest.Rd
@@ -27,7 +27,7 @@ A superclass for methods wrapping Rest API responses.
 \subsection{Method \code{new()}}{
 Create a new \code{Rest} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRest$new(rest_api_url = NA, token = NA, scan_whole_host)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineRest$new(rest_api_url = NA, token = NA, scan_all)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -37,7 +37,7 @@ Create a new \code{Rest} object
 
 \item{\code{token}}{A token.}
 
-\item{\code{scan_whole_host}}{A boolean.}
+\item{\code{scan_all}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineRestGitHub.Rd
+++ b/man/EngineRestGitHub.Rd
@@ -35,7 +35,7 @@ A class for methods wrapping GitHub's REST API responses.
 \subsection{Method \code{new()}}{
 Create new \code{EngineRestGitHub} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitHub$new(rest_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitHub$new(rest_api_url, token, scan_all)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -45,7 +45,7 @@ Create new \code{EngineRestGitHub} object.
 
 \item{\code{token}}{A token.}
 
-\item{\code{scan_whole_host}}{A boolean.}
+\item{\code{scan_all}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineRestGitHub.Rd
+++ b/man/EngineRestGitHub.Rd
@@ -35,7 +35,7 @@ A class for methods wrapping GitHub's REST API responses.
 \subsection{Method \code{new()}}{
 Create new \code{EngineRestGitHub} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitHub$new(rest_api_url, token)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitHub$new(rest_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -44,6 +44,8 @@ Create new \code{EngineRestGitHub} object.
 \item{\code{rest_api_url}}{A REST API url.}
 
 \item{\code{token}}{A token.}
+
+\item{\code{scan_whole_host}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineRestGitHub.Rd
+++ b/man/EngineRestGitHub.Rd
@@ -12,8 +12,6 @@ A class for methods wrapping GitHub's REST API responses.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{EngineRestGitHub$new()}}
-\item \href{#method-check_organizations}{\code{EngineRestGitHub$check_organizations()}}
 \item \href{#method-get_repos}{\code{EngineRestGitHub$get_repos()}}
 \item \href{#method-get_repos_supportive}{\code{EngineRestGitHub$get_repos_supportive()}}
 \item \href{#method-get_commits}{\code{EngineRestGitHub$get_commits()}}
@@ -25,50 +23,11 @@ A class for methods wrapping GitHub's REST API responses.
 \if{html}{
 \out{<details open ><summary>Inherited methods</summary>}
 \itemize{
+\item \out{<span class="pkg-link" data-pkg="GitStats" data-topic="EngineRest" data-id="check_organizations">}\href{../../GitStats/html/EngineRest.html#method-check_organizations}{\code{GitStats::EngineRest$check_organizations()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="GitStats" data-topic="EngineRest" data-id="initialize">}\href{../../GitStats/html/EngineRest.html#method-initialize}{\code{GitStats::EngineRest$initialize()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="GitStats" data-topic="EngineRest" data-id="response">}\href{../../GitStats/html/EngineRest.html#method-response}{\code{GitStats::EngineRest$response()}}\out{</span>}
 }
 \out{</details>}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
-\subsection{Method \code{new()}}{
-Create new \code{EngineRestGitHub} object.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitHub$new(rest_api_url, token, scan_all)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{rest_api_url}}{A REST API url.}
-
-\item{\code{token}}{A token.}
-
-\item{\code{scan_all}}{A boolean.}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-check_organizations"></a>}}
-\if{latex}{\out{\hypertarget{method-check_organizations}{}}}
-\subsection{Method \code{check_organizations()}}{
-Check if an organization exists
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitHub$check_organizations(orgs)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{orgs}}{A character vector of organizations}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-orgs or NULL.
-}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-get_repos"></a>}}

--- a/man/EngineRestGitLab.Rd
+++ b/man/EngineRestGitLab.Rd
@@ -34,7 +34,7 @@ A class for methods wrapping GitLab's REST API responses.
 \subsection{Method \code{new()}}{
 Create new \code{EngineRestGitLab} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitLab$new(rest_api_url, token)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitLab$new(rest_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -43,6 +43,8 @@ Create new \code{EngineRestGitLab} object.
 \item{\code{rest_api_url}}{A REST API url.}
 
 \item{\code{token}}{A token.}
+
+\item{\code{scan_whole_host}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/EngineRestGitLab.Rd
+++ b/man/EngineRestGitLab.Rd
@@ -12,8 +12,6 @@ A class for methods wrapping GitLab's REST API responses.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{EngineRestGitLab$new()}}
-\item \href{#method-check_organizations}{\code{EngineRestGitLab$check_organizations()}}
 \item \href{#method-get_repos}{\code{EngineRestGitLab$get_repos()}}
 \item \href{#method-get_repos_supportive}{\code{EngineRestGitLab$get_repos_supportive()}}
 \item \href{#method-add_repos_contributors}{\code{EngineRestGitLab$add_repos_contributors()}}
@@ -24,50 +22,11 @@ A class for methods wrapping GitLab's REST API responses.
 \if{html}{
 \out{<details open ><summary>Inherited methods</summary>}
 \itemize{
+\item \out{<span class="pkg-link" data-pkg="GitStats" data-topic="EngineRest" data-id="check_organizations">}\href{../../GitStats/html/EngineRest.html#method-check_organizations}{\code{GitStats::EngineRest$check_organizations()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="GitStats" data-topic="EngineRest" data-id="initialize">}\href{../../GitStats/html/EngineRest.html#method-initialize}{\code{GitStats::EngineRest$initialize()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="GitStats" data-topic="EngineRest" data-id="response">}\href{../../GitStats/html/EngineRest.html#method-response}{\code{GitStats::EngineRest$response()}}\out{</span>}
 }
 \out{</details>}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
-\subsection{Method \code{new()}}{
-Create new \code{EngineRestGitLab} object.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitLab$new(rest_api_url, token, scan_all)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{rest_api_url}}{A REST API url.}
-
-\item{\code{token}}{A token.}
-
-\item{\code{scan_all}}{A boolean.}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-check_organizations"></a>}}
-\if{latex}{\out{\hypertarget{method-check_organizations}{}}}
-\subsection{Method \code{check_organizations()}}{
-Check if an organization exists
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitLab$check_organizations(orgs)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{orgs}}{A character vector of organizations}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-orgs or NULL.
-}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-get_repos"></a>}}

--- a/man/EngineRestGitLab.Rd
+++ b/man/EngineRestGitLab.Rd
@@ -34,7 +34,7 @@ A class for methods wrapping GitLab's REST API responses.
 \subsection{Method \code{new()}}{
 Create new \code{EngineRestGitLab} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitLab$new(rest_api_url, token, scan_whole_host)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{EngineRestGitLab$new(rest_api_url, token, scan_all)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -44,7 +44,7 @@ Create new \code{EngineRestGitLab} object.
 
 \item{\code{token}}{A token.}
 
-\item{\code{scan_whole_host}}{A boolean.}
+\item{\code{scan_all}}{A boolean.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/GQLQueryGitHub.Rd
+++ b/man/GQLQueryGitHub.Rd
@@ -9,11 +9,32 @@ A class with methods to build GraphQL Queries for GitHub.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
+\item \href{#method-orgs}{\code{GQLQueryGitHub$orgs()}}
 \item \href{#method-repos_by_org}{\code{GQLQueryGitHub$repos_by_org()}}
 \item \href{#method-repos_by_user}{\code{GQLQueryGitHub$repos_by_user()}}
 \item \href{#method-user}{\code{GQLQueryGitHub$user()}}
 \item \href{#method-commits_by_repo}{\code{GQLQueryGitHub$commits_by_repo()}}
 \item \href{#method-clone}{\code{GQLQueryGitHub$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-orgs"></a>}}
+\if{latex}{\out{\hypertarget{method-orgs}{}}}
+\subsection{Method \code{orgs()}}{
+Prepare query to list organizations from GitHub.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{GQLQueryGitHub$orgs(end_cursor)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{end_cursor}}{An end cursor to paginate.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A query.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/GQLQueryGitLab.Rd
+++ b/man/GQLQueryGitLab.Rd
@@ -9,9 +9,23 @@ A class with methods to build GraphQL Queries for GitLab.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
+\item \href{#method-groups}{\code{GQLQueryGitLab$groups()}}
 \item \href{#method-repos_by_org}{\code{GQLQueryGitLab$repos_by_org()}}
 \item \href{#method-user}{\code{GQLQueryGitLab$user()}}
 \item \href{#method-clone}{\code{GQLQueryGitLab$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-groups"></a>}}
+\if{latex}{\out{\hypertarget{method-groups}{}}}
+\subsection{Method \code{groups()}}{
+Prepare query to list groups from GitLab.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{GQLQueryGitLab$groups()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+A query.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/set_connection.Rd
+++ b/man/set_connection.Rd
@@ -4,7 +4,7 @@
 \alias{set_connection}
 \title{Setting connections}
 \usage{
-set_connection(gitstats_obj, api_url, token = NULL, orgs)
+set_connection(gitstats_obj, api_url, token = NULL, orgs = NULL)
 }
 \arguments{
 \item{gitstats_obj}{A GitStats object.}
@@ -13,8 +13,12 @@ set_connection(gitstats_obj, api_url, token = NULL, orgs)
 
 \item{token}{A token.}
 
-\item{orgs}{A character vector of organisations (owners of repositories
-in case of GitHub and groups of projects in case of GitLab).}
+\item{orgs}{A character vector of organisations (owners of repositories in
+case of GitHub and groups of projects in case of GitLab). You do not need
+to define \code{orgs} if you wish to scan whole internal Git platform (such as
+enterprise version of GitHub or GitLab). In case of a public one (like
+GitHub) you need to define \code{orgs} as scanning through all organizations
+would be an overkill.}
 }
 \value{
 A \code{GitStats} class object with added information on connection

--- a/tests/testthat/_snaps/GitHost.md
+++ b/tests/testthat/_snaps/GitHost.md
@@ -14,6 +14,13 @@
     Message <cliMessage>
       i Using PAT from GITLAB_PAT envar.
 
+# GitHost pulls repos from orgs
+
+    Code
+      gh_repos_table <- test_host$pull_repos_from_orgs(settings)
+    Message <cliMessage>
+      i [GitHub][Engine:GraphQL][org:r-world-devs] Pulling repositories...
+
 # GitHost filters GitHub repositories' (pulled by org) table by languages
 
     Code
@@ -55,6 +62,15 @@
       result <- test_host$filter_repos_by_language(gl_repos_table, language = "C")
     Message <cliMessage>
       i Filtering by language.
+
+# get_repos returns table of repositories
+
+    Code
+      repos_table <- test_host$get_repos(settings = list(search_param = "org",
+        language = "All"))
+    Message <cliMessage>
+      i [GitHub][Engine:GraphQL][org:openpharma] Pulling repositories...
+      i [GitHub][Engine:GraphQL][org:r-world-devs] Pulling repositories...
 
 # add_repos_contributors returns table with contributors
 

--- a/tests/testthat/_snaps/GitStats.md
+++ b/tests/testthat/_snaps/GitStats.md
@@ -5,7 +5,7 @@
     Output
       A <GitStats> object for 0 hosts:
       Hosts: 
-      Organisations: 
+      Organisations: [0] 
       Search preference: org
       Team: <not defined>
       Phrase: <not defined>
@@ -20,7 +20,7 @@
     Output
       A <GitStats> object for 2 hosts:
       Hosts: https://api.github.com, https://gitlab.com/api/v4
-      Organisations: r-world-devs, openpharma, mbtests
+      Organisations: [3] r-world-devs, openpharma, mbtests
       Search preference: org
       Team: <not defined>
       Phrase: <not defined>
@@ -35,7 +35,7 @@
     Output
       A <GitStats> object for 2 hosts:
       Hosts: https://api.github.com, https://gitlab.com/api/v4
-      Organisations: r-world-devs, openpharma, mbtests
+      Organisations: [3] r-world-devs, openpharma, mbtests
       Search preference: team
       Team: RWD-IE (0 members)
       Phrase: <not defined>

--- a/tests/testthat/_snaps/reset_language.md
+++ b/tests/testthat/_snaps/reset_language.md
@@ -7,7 +7,7 @@
     Output
       A <GitStats> object for 2 hosts:
       Hosts: https://api.github.com, https://gitlab.com/api/v4
-      Organisations: r-world-devs, openpharma, mbtests
+      Organisations: [3] r-world-devs, openpharma, mbtests
       Search preference: phrase
       Team: <not defined>
       Phrase: test-phrase

--- a/tests/testthat/_snaps/set_connection.md
+++ b/tests/testthat/_snaps/set_connection.md
@@ -40,7 +40,7 @@
       test_gitstats %>% set_connection(api_url = "https://api.github.com", token = Sys.getenv(
         "GITHUB_PAT"))
     Message <cliMessage>
-      ! argument "orgs" is missing, with no default
+      ! You need to specify `orgs` for public Git platform.
       x Host will not be passed.
 
 # Warning shows, when wrong input is passed when setting connection and host is not passed

--- a/tests/testthat/_snaps/set_connection.md
+++ b/tests/testthat/_snaps/set_connection.md
@@ -34,23 +34,16 @@
       i Using PAT from GITLAB_PAT envar.
       v Set connection to GitLab.
 
-# Warning shows if organizations are not specified and host is not passed
+# Error shows if organizations are not specified and host is not passed
 
-    Code
-      test_gitstats %>% set_connection(api_url = "https://api.github.com", token = Sys.getenv(
-        "GITHUB_PAT"))
-    Message <cliMessage>
-      ! You need to specify `orgs` for public Git platform.
-      x Host will not be passed.
+    You need to specify `orgs` for public Git Host.
+    x Host will not be added.
+    i Add organizations to your `orgs` parameter.
 
-# Warning shows, when wrong input is passed when setting connection and host is not passed
+# Error shows, when wrong input is passed when setting connection and host is not passed
 
-    Code
-      set_connection(gitstats_obj = test_gitstats, api_url = "https://avengers.com",
-        token = Sys.getenv("GITLAB_PAT_PUBLIC"))
-    Message <cliMessage>
-      ! This connection is not supported by GitStats class object.
-      x Host will not be passed.
+    This connection is not supported by GitStats class object.
+    x Host will not be added.
 
 # Error pops out, when two clients of the same url api are passed as input
 
@@ -71,7 +64,9 @@
       test_gitstats <- create_gitstats() %>% set_connection(api_url = "https://api.github.com",
         token = Sys.getenv("GITHUB_PAT"), orgs = c("openparma"))
     Message <cliMessage>
-      x Organization you provided does not exist. Check spelling in: openparma
+      x Organization you provided does not exist or its name was passed in a wrong way: openparma
+      ! Please type your organization name as you see it in `url`.
+      i E.g. do not use spaces. Organization names as you see on the page may differ from their 'address' name.
     Message <simpleMessage>
       HTTP 404 No such address
     Message <cliMessage>
@@ -83,23 +78,9 @@
       test_gitstats <- create_gitstats() %>% set_connection(api_url = "https://gitlab.com/api/v4",
         token = Sys.getenv("GITLAB_PAT_PUBLIC"), orgs = c("openparma", "mbtests"))
     Message <cliMessage>
-      x Group name passed in a wrong way: openparma
-      ! If you are using `GitLab`, please type your group name as you see it in `url`.
-      i E.g. do not use spaces. Group names as you see on the page may differ from their 'address' name.
-    Message <simpleMessage>
-      HTTP 404 No such address
-    Message <cliMessage>
-      v Set connection to GitLab.
-
-# Error with message pops out, when you pass to your `GitLab` connection group name as you see it on the page (not from url)
-
-    Code
-      test_gitstats <- create_gitstats() %>% set_connection(api_url = "https://gitlab.com/api/v4",
-        token = Sys.getenv("GITLAB_PAT_PUBLIC"), orgs = "MB Tests")
-    Message <cliMessage>
-      x Group name passed in a wrong way: MB Tests
-      ! If you are using `GitLab`, please type your group name as you see it in `url`.
-      i E.g. do not use spaces. Group names as you see on the page may differ from their 'address' name.
+      x Organization you provided does not exist or its name was passed in a wrong way: openparma
+      ! Please type your organization name as you see it in `url`.
+      i E.g. do not use spaces. Organization names as you see on the page may differ from their 'address' name.
     Message <simpleMessage>
       HTTP 404 No such address
     Message <cliMessage>
@@ -108,14 +89,14 @@
 ---
 
     Code
-      test_gitstats <- create_gitstats() %>% set_connection(api_url = "https://gitlab.com/api/v4",
-        token = Sys.getenv("GITLAB_PAT_PUBLIC"), orgs = c("mbtests", "MB Tests"))
+      test_gitstats <- create_gitstats() %>% set_connection(api_url = "https://api.github.com",
+        token = Sys.getenv("GITHUB_PAT"), orgs = c("openpharma", "r_world_devs"))
     Message <cliMessage>
-      x Group name passed in a wrong way: MB Tests
-      ! If you are using `GitLab`, please type your group name as you see it in `url`.
-      i E.g. do not use spaces. Group names as you see on the page may differ from their 'address' name.
+      x Organization you provided does not exist or its name was passed in a wrong way: r_world_devs
+      ! Please type your organization name as you see it in `url`.
+      i E.g. do not use spaces. Organization names as you see on the page may differ from their 'address' name.
     Message <simpleMessage>
       HTTP 404 No such address
     Message <cliMessage>
-      v Set connection to GitLab.
+      v Set connection to GitHub.
 

--- a/tests/testthat/_snaps/setup.md
+++ b/tests/testthat/_snaps/setup.md
@@ -11,7 +11,7 @@
     Output
       A <GitStats> object for 0 hosts:
       Hosts: 
-      Organisations: 
+      Organisations: [0] 
       Search preference: phrase
       Team: RWD-IE (0 members)
       Phrase: covid
@@ -28,7 +28,7 @@
     Output
       A <GitStats> object for 0 hosts:
       Hosts: 
-      Organisations: 
+      Organisations: [0] 
       Search preference: org
       Team: RWD-IE (0 members)
       Phrase: covid
@@ -43,7 +43,7 @@
     Output
       A <GitStats> object for 0 hosts:
       Hosts: 
-      Organisations: 
+      Organisations: [0] 
       Search preference: org
       Team: RWD-IE (0 members)
       Phrase: covid

--- a/tests/testthat/test-02-EngineRest.R
+++ b/tests/testthat/test-02-EngineRest.R
@@ -68,7 +68,7 @@ test_that("`response()` returns search response from GitHub's REST API", {
   test_mocker$cache(gh_search_response)
 })
 
-test_rest <- EngineRest$new(
+test_rest <- create_testrest(
   rest_api_url = "https://gitlab.com/api/v4",
   token = Sys.getenv("GITLAB_PAT_PUBLIC")
 )

--- a/tests/testthat/test-GitHost.R
+++ b/tests/testthat/test-GitHost.R
@@ -113,6 +113,25 @@ test_that("`test_token` works properly", {
     test_host$test_token("false_token")
   )
 })
+suppressMessages(
+  test_host <- GitHost$new(
+    api_url = "https://api.github.com",
+    token = Sys.getenv("GITHUB_PAT"),
+    orgs = "r-world-devs"
+  )
+)
+test_host <- test_host$.__enclos_env__$private
+
+test_that("`setup_engine` adds engines to host", {
+  expect_s3_class(
+    test_host$setup_engine(type = "rest"),
+    "EngineRest"
+  )
+  expect_s3_class(
+    test_host$setup_engine(type = "graphql"),
+    "EngineGraphQL"
+  )
+})
 
 test_that("`set_gql_url()` correctly sets gql api url - for public GitHub", {
   expect_equal(
@@ -125,6 +144,16 @@ test_that("`set_gql_url()` correctly sets gql api url - for public GitLab", {
   expect_equal(
     test_host$set_gql_url("https://gitlab.com/api/v4"),
     "https://gitlab.com/api/graphql"
+  )
+})
+
+test_that("GitHost pulls repos from orgs", {
+  settings <- list(search_param = "org")
+  expect_snapshot(
+    gh_repos_table <- test_host$pull_repos_from_orgs(settings)
+  )
+  expect_repos_table(
+    gh_repos_table
   )
 })
 
@@ -261,6 +290,23 @@ test_host <- create_testhost(
   token = Sys.getenv("GITHUB_PAT"),
   orgs = c("openpharma", "r-world-devs")
 )
+
+test_that("get_repos returns table of repositories", {
+  mockery::stub(
+    test_host$get_repos,
+    "private$pull_repos_from_org",
+    test_mocker$use("gh_repos_table")
+  )
+  expect_snapshot(
+    repos_table <- test_host$get_repos(
+      settings = list(search_param = "org",
+                      language = "All")
+    )
+  )
+  expect_repos_table(
+    repos_table
+  )
+})
 
 test_that("add_repos_contributors returns table with contributors", {
 

--- a/tests/testthat/test-GitHost.R
+++ b/tests/testthat/test-GitHost.R
@@ -22,6 +22,40 @@ test_host <- create_testhost(
   mode = "private"
 )
 
+test_that("`check_if_public` checks correctly if Git Platform is public or not", {
+  expect_true(
+    test_host$check_if_public("https://api.github.com")
+  )
+  expect_true(
+    test_host$check_if_public("https://gitlab.com/api/v4")
+  )
+  expect_false(
+    test_host$check_if_public("https://code.internal.com/api/v4")
+  )
+  expect_false(
+    test_host$check_if_public("https://github.internal.com/api/v4")
+  )
+})
+
+test_that("`set_host_name` checks correctly if Git Platform is public or not", {
+  expect_equal(
+    test_host$set_host_name("https://api.github.com"),
+    "GitHub"
+  )
+  expect_equal(
+    test_host$set_host_name("https://gitlab.com/api/v4"),
+    "GitLab"
+  )
+  expect_equal(
+    test_host$set_host_name("https://code.internal.com/api/v4"),
+    "GitLab"
+  )
+  expect_equal(
+    test_host$set_host_name("https://github.internal.com/api/v4"),
+    "GitHub"
+  )
+})
+
 test_that("`set_default_token` sets default token for public GitHub", {
   expect_snapshot(
     default_token <- test_host$set_default_token()

--- a/tests/testthat/test-GitHost.R
+++ b/tests/testthat/test-GitHost.R
@@ -15,46 +15,57 @@ test_that("GitHost gets users tables", {
 
 # private methods
 
+test_that("`check_if_public` and `set_host` work correctly", {
+  test_host <- create_testhost(
+    api_url = "https://api.github.com",
+    mode = "private"
+  )
+  expect_true(
+    test_host$check_if_public()
+  )
+  expect_equal(
+    test_host$set_host(),
+    "GitHub"
+  )
+  test_host <- create_testhost(
+    api_url = "https://gitlab.com/api/v4",
+    mode = "private"
+  )
+  expect_true(
+    test_host$check_if_public()
+  )
+  expect_equal(
+    test_host$set_host(),
+    "GitLab"
+  )
+  test_host <- create_testhost(
+    api_url = "https://code.internal.com/api/v4",
+    mode = "private"
+  )
+  expect_false(
+    test_host$check_if_public()
+  )
+  expect_equal(
+    test_host$set_host(),
+    "GitLab"
+  )
+  test_host <- create_testhost(
+    api_url = "https://github.internal.com/api/v4",
+    mode = "private"
+  )
+  expect_false(
+    test_host$check_if_public()
+  )
+  expect_equal(
+    test_host$set_host(),
+    "GitHub"
+  )
+})
+
 test_host <- create_testhost(
   api_url = "https://api.github.com",
-  token = Sys.getenv("GITHUB_PAT"),
-  orgs = c("openpharma", "r-world-devs"),
   mode = "private"
 )
-
-test_that("`check_if_public` checks correctly if Git Platform is public or not", {
-  expect_true(
-    test_host$check_if_public("https://api.github.com")
-  )
-  expect_true(
-    test_host$check_if_public("https://gitlab.com/api/v4")
-  )
-  expect_false(
-    test_host$check_if_public("https://code.internal.com/api/v4")
-  )
-  expect_false(
-    test_host$check_if_public("https://github.internal.com/api/v4")
-  )
-})
-
-test_that("`set_host_name` checks correctly if Git Platform is public or not", {
-  expect_equal(
-    test_host$set_host_name("https://api.github.com"),
-    "GitHub"
-  )
-  expect_equal(
-    test_host$set_host_name("https://gitlab.com/api/v4"),
-    "GitLab"
-  )
-  expect_equal(
-    test_host$set_host_name("https://code.internal.com/api/v4"),
-    "GitLab"
-  )
-  expect_equal(
-    test_host$set_host_name("https://github.internal.com/api/v4"),
-    "GitHub"
-  )
-})
 
 test_that("`set_default_token` sets default token for public GitHub", {
   expect_snapshot(

--- a/tests/testthat/test-set_connection.R
+++ b/tests/testthat/test-set_connection.R
@@ -40,21 +40,25 @@ test_that("When empty token for GitLab, GitStats pulls default token", {
   )
 })
 
-test_that("Warning shows if organizations are not specified and host is not passed", {
+test_that("Error shows if organizations are not specified and host is not passed", {
   test_gitstats <- create_gitstats()
-  expect_snapshot(
+  expect_snapshot_error(
     test_gitstats %>%
       set_connection(
         api_url = "https://api.github.com",
         token = Sys.getenv("GITHUB_PAT")
       )
   )
+  expect_length(
+    test_gitstats$.__enclos_env__$private$hosts,
+    0
+  )
 })
 
-test_that("Warning shows, when wrong input is passed when setting connection and host is not passed", {
+test_that("Error shows, when wrong input is passed when setting connection and host is not passed", {
   test_gitstats <- create_gitstats()
 
-  expect_snapshot(
+  expect_snapshot_error(
     set_connection(
       gitstats_obj = test_gitstats,
       api_url = "https://avengers.com",
@@ -100,26 +104,13 @@ test_that("`Org` name is not passed to the object if it does not exist", {
         orgs = c("openparma", "mbtests")
       )
   )
-})
-
-test_that("Error with message pops out, when you pass to your `GitLab` connection group name as you see it on the page (not from url)", {
-  testthat::skip_on_ci()
 
   expect_snapshot(
     test_gitstats <- create_gitstats() %>%
       set_connection(
-        api_url = "https://gitlab.com/api/v4",
-        token = Sys.getenv("GITLAB_PAT_PUBLIC"),
-        orgs = "MB Tests"
-      )
-  )
-
-  expect_snapshot(
-    test_gitstats <- create_gitstats() %>%
-      set_connection(
-        api_url = "https://gitlab.com/api/v4",
-        token = Sys.getenv("GITLAB_PAT_PUBLIC"),
-        orgs = c("mbtests", "MB Tests")
+        api_url = "https://api.github.com",
+        token = Sys.getenv("GITHUB_PAT"),
+        orgs = c("openpharma", "r_world_devs")
       )
   )
 })


### PR DESCRIPTION
Adding possibility to scan all git platforms by:
- adding method to **pull all organizations** (GraphQL based),

... with few code optimizations:

- wrapping some code chunks in GitHost into separate function (`setup_engines`) and adding some helpers (`set_host`, `check_if_public`)
- moving two methods (`initialize` and `check_organizations`) from Engine Rest subclasses to the superclass,
- removing error handling when setting connection in `GitStats` (improving messages to user).
