### PR TITLE
Fix pulling users when error on response occurs. 

### DIFF
--- a/R/EngineGraphQL.R
+++ b/R/EngineGraphQL.R
@@ -79,15 +79,13 @@ EngineGraphQL <- R6::R6Class("EngineGraphQL",
      # @param username A login.
      # @return A user response.
      pull_user = function(username) {
-       response <- self$gql_response(
-         gql_query = self$gql_query$user(),
-         vars = list("user" = username)
-       )
-       if (length(response$errors) > 0) {
-         cli::cli_abort(
-           response$errors[[1]]$message
+       response <- NULL
+       try(
+         response <- self$gql_response(
+           gql_query = self$gql_query$user(),
+           vars = list("user" = username)
          )
-       }
+       )
        return(response)
      }
    )


### PR DESCRIPTION
Error should not pop out and kill all the process if e.g. graphql can not find a user with the login that does not match git org.