### PR TITLE
Add paginate helper to manage pagination of contributors...

### DIFF
--- a/R/EngineRest.R
+++ b/R/EngineRest.R
@@ -128,6 +128,34 @@ EngineRest <- R6::R6Class("EngineRest",
       return(object)
     },
 
+    # Paginate contributors and parse response into character vector
+    pull_contributors_from_repo = function(contributors_endpoint, user_name) {
+      contributors_response <- private$paginate_results(contributors_endpoint)
+      contributors_vec <- contributors_response %>%
+        purrr::map_chr(~ eval(user_name)) %>%
+        paste0(collapse = ", ")
+      return(contributors_vec)
+    },
+
+    # Helper
+    paginate_results = function(endpoint, joining_sign = "?") {
+      full_response <- list()
+      page <- 1
+      repeat {
+        endpoint_with_pagination <- paste0(endpoint, joining_sign, "per_page=100&page=", page)
+        response_page <- self$response(
+          endpoint = endpoint_with_pagination
+        )
+        if (length(response_page) > 0) {
+          full_response <- append(full_response, response_page)
+          page <- page + 1
+        } else {
+          break
+        }
+      }
+      return(full_response)
+    },
+
     # @description A helper to prepare table for repositories content
     # @param repos_list A repository list.
     # @return A data.frame.

--- a/tests/testthat/_snaps/06-GitStats.md
+++ b/tests/testthat/_snaps/06-GitStats.md
@@ -133,5 +133,5 @@
       Storage: 
        Repositories: 17 rows x 13 cols
        Commits: 73 rows x 8 cols
-       R_package_usage: 11 rows x 4 cols
+       R_package_usage: 12 rows x 4 cols
 

--- a/tests/testthat/_snaps/06-GitStats.md
+++ b/tests/testthat/_snaps/06-GitStats.md
@@ -133,5 +133,5 @@
       Storage: 
        Repositories: 17 rows x 13 cols
        Commits: 73 rows x 8 cols
-       R_package_usage: 12 rows x 4 cols
+       R_package_usage: 11 rows x 4 cols
 

--- a/tests/testthat/test-03-EngineRestGitHub.R
+++ b/tests/testthat/test-03-EngineRestGitHub.R
@@ -135,11 +135,15 @@ test_that("`pull_repos_issues()` adds issues to repos table", {
   test_mocker$cache(gh_repos_by_phrase_table)
 })
 
-test_that("`pull_commits_from_repo()` pulls all commits from repository", {
-  commits_from_repo <- test_rest_priv$pull_commits_from_repo(
-    repo_fullname = "r-world-devs/GitStats",
-    date_from = "2023-01-01",
-    date_until = "2023-06-01"
+test_that("`paginate_results()` pulls all commits from repository", {
+  commits_endpoint <- paste0(
+    "https://api.github.com/repos/r-world-devs/GitStats/commits?since=",
+    date_to_gts("2023-01-01"),
+    "&until=",
+    date_to_gts("2023-06-01")
+  )
+  commits_from_repo <- test_rest_priv$paginate_results(
+    endpoint = commits_endpoint
   )
   expect_gh_commit_rest_response(
     commits_from_repo


### PR DESCRIPTION
...as well as commits and reposiotires.

Closes #331 

Use this workflow to see if contributors excess the limit of 30:

```
git_stats <- create_gitstats() %>%
  set_host(
    api_url = "https://api.github.com",
    org = "UCL"
  ) %>%
  pull_repos(add_contributors = TRUE)

get_repos_stats(git_stats) %>%
  gitstats_plot(
    value_to_plot = "contributors_n",
    value_decreasing = FALSE
  )
```