### PR TITLE
411 try speed up get files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GitStats
 Title: Get Statistics from GitHub and GitLab
-Version: 2.0.0
+Version: 2.0.0.9000
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
     person(given = "Kamil", family = "Koziej", email = "koziej.k@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# GitStats (development version)
+
+- Getting files feature has been speeded up with switching to `Search API` instead of pulling files via `GraphQL` via iteration over organizations and repositories ([#411](https://github.com/r-world-devs/GitStats/issues/411)).
+- When setting hosts to be scanned in whole (without specifying `orgs` or `repos`) GitStats does not pull no more all organizations. Pulling all organizations from host is triggered only when user decides to pull repositories from organizations. If he decides, e.g. to pull repositories by code, there is no need to pull all organizations (which may be a time consuming process), as GitStats uses then `Search API` ([#393](https://github.com/r-world-devs/GitStats/issues/393)).
+
 # GitStats 2.0.0
 
 This is a major release with general changes in workflow (simplifying it), changes in setting `GitStats` hosts, deprecation of some not very useful features (like plots, setting parameters separately) and new `get_release_logs()` function.

--- a/R/EngineGraphQLGitHub.R
+++ b/R/EngineGraphQLGitHub.R
@@ -84,19 +84,12 @@ EngineGraphQLGitHub <- R6::R6Class("EngineGraphQLGitHub",
     },
 
     # Pull all given files from all repositories of an organization.
-    pull_files_from_org = function(org, file_path, pulled_repos = NULL) {
-      if (is.null(pulled_repos)) {
-        repos_list <- self$pull_repos_from_org(
-          org = org
-        )
-        repositories <- purrr::map(repos_list, ~ .$repo_name)
-        def_branches <- purrr::map(repos_list, ~ .$default_branch$name)
-      } else {
-        repos_table <- pulled_repos %>%
-          dplyr::filter(organization == org)
-        repositories <- repos_table$repo_name
-        def_branches <- repos_table$default_branch
-      }
+    pull_files_from_org = function(org, file_path) {
+      repos_list <- self$pull_repos_from_org(
+        org = org
+      )
+      repositories <- purrr::map(repos_list, ~ .$repo_name)
+      def_branches <- purrr::map(repos_list, ~ .$default_branch$name)
       files_list <- purrr::map(file_path, function(file_path) {
         files_list <- purrr::map2(repositories, def_branches, function(repository, def_branch) {
           files_query <- self$gql_query$files_by_repo()

--- a/R/EngineRest.R
+++ b/R/EngineRest.R
@@ -51,13 +51,13 @@ EngineRest <- R6::R6Class("EngineRest",
     },
 
     # Filtering handler if files are set for scanning scope
-    limit_search_to_files = function(repos_list, files) {
+    limit_search_to_files = function(search_result, files) {
       if (!is.null(files)) {
-        repos_list <- purrr::keep(repos_list, function(repository) {
+        search_result <- purrr::keep(search_result, function(repository) {
           any(repository$path %in% files)
         })
       }
-      return(repos_list)
+      return(search_result)
     },
 
     # Helper

--- a/R/EngineRestGitHub.R
+++ b/R/EngineRestGitHub.R
@@ -14,8 +14,9 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
           search_result <- private$search_response(
             search_endpoint = search_file_endpoint,
             total_n = total_n
-          )
-          files_content <- private$get_files_content(search_result)
+          ) %>%
+            purrr::keep(~ .$path == filename)
+          files_content <- private$get_files_content(search_result, filename)
           files_list <- append(files_list, files_content)
         }
       }
@@ -217,8 +218,9 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
     },
 
     # Get files content
-    get_files_content = function(search_result) {
-      purrr::map(search_result, ~ self$response(.$url)) %>%
+    get_files_content = function(search_result, filename) {
+      purrr::map(search_result, ~ self$response(.$url),
+                 .progress = glue::glue("Adding file [{filename}] info...")) %>%
         unique()
     }
   )

--- a/R/EngineRestGitHub.R
+++ b/R/EngineRestGitHub.R
@@ -43,7 +43,7 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
           total_n = total_n
         )
         search_result <- private$limit_search_to_files(
-          repos_list = repos_list,
+          search_result = search_result,
           files = settings$files
         )
         repos_list <- private$map_search_into_repos(

--- a/R/EngineRestGitHub.R
+++ b/R/EngineRestGitHub.R
@@ -4,15 +4,29 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
   inherit = EngineRest,
   public = list(
 
+    # Pull repositories with files
+    pull_files = function(files) {
+      files_list <- list()
+      for (filename in files) {
+        search_file_endpoint <- paste0(private$endpoints[["search"]], "filename:", filename)
+        total_n <- self$response(search_file_endpoint)[["total_count"]]
+        if (length(total_n) > 0) {
+          search_result <- private$search_response(
+            search_endpoint = search_file_endpoint,
+            total_n = total_n
+          )
+          files_content <- private$get_files_content(search_result)
+          files_list <- append(files_list, files_content)
+        }
+      }
+      return(files_list)
+    },
+
     # Pulling repositories where code appears
-    # @param byte_max According to GitHub documentation only files smaller than
-    #   384 KB are searchable. See
-    #   \link{https://docs.github.com/en/rest/search?apiVersion=2022-11-28#search-code}
     pull_repos_by_code = function(org = NULL,
                                   code,
                                   verbose,
-                                  settings,
-                                  byte_max = "384000") {
+                                  settings) {
       private$set_verbose(verbose)
       user_query <- if (!is.null(org)) {
         paste0('+user:', org)
@@ -24,17 +38,16 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
       total_n <- self$response(search_endpoint)[["total_count"]]
       if (verbose) cli::cli_alert_info("Searching for code [{code}]...")
       if (length(total_n) > 0) {
-        repos_list <- private$search_response(
+        search_result <- private$search_response(
           search_endpoint = search_endpoint,
-          total_n = total_n,
-          byte_max = byte_max
+          total_n = total_n
         )
-        repos_list <- private$limit_search_to_files(
+        search_result <- private$limit_search_to_files(
           repos_list = repos_list,
           files = settings$files
         )
         repos_list <- private$map_search_into_repos(
-          search_response = repos_list
+          search_response = search_result
         )
       } else {
         repos_list <- list()
@@ -123,10 +136,12 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
     # A wrapper for proper pagination of GitHub search REST API
     # @param search_endpoint A character, a search endpoint
     # @param total_n Number of results
-    # @param byte_max Max byte size
+    # @param byte_max According to GitHub documentation only files smaller than
+    #   384 KB are searchable. See
+    #   \link{https://docs.github.com/en/rest/search?apiVersion=2022-11-28#search-code}
     search_response = function(search_endpoint,
                                total_n,
-                               byte_max) {
+                               byte_max = "384000") {
       if (total_n >= 0 & total_n < 1e3) {
         resp_list <- list()
         for (page in 1:(total_n %/% 100)) {
@@ -199,6 +214,12 @@ EngineRestGitHub <- R6::R6Class("EngineRestGitHub",
           FALSE
         })
       repos_list
+    },
+
+    # Get files content
+    get_files_content = function(search_result) {
+      purrr::map(search_result, ~ self$response(.$url)) %>%
+        unique()
     }
   )
 )

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -4,6 +4,24 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
   inherit = EngineRest,
   public = list(
 
+    # Pull repositories with files
+    pull_files = function(files) {
+      files_list <- list()
+      for (filename in files) {
+        files_search_result <- private$search_for_code(
+          code = paste0("path:", filename),
+          settings = list()
+        ) %>%
+          purrr::keep(~ .$path == filename)
+        files_content <- private$add_file_content(
+          files_search_result = files_search_result,
+          filename = filename
+        )
+        files_list <- append(files_list, files_content)
+      }
+      return(files_list)
+    },
+
     # Wrapper for iteration over GitLab search API response
     # @details For the time being there is no possibility to search GitLab with
     #   filtering by language. For more information look here:
@@ -11,39 +29,13 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     pull_repos_by_code = function(org = NULL,
                                   code,
                                   verbose,
-                                  settings,
-                                  page_max = 1e6) {
+                                  settings) {
       private$set_verbose(verbose)
-      page <- 1
-      still_more_hits <- TRUE
-      full_repos_list <- list()
-      private$set_search_endpoint(org)
-      if (private$verbose) {
-        cli::cli_alert_info("[GitLab] Searching for code...")
-      }
-      while (still_more_hits | page < page_max) {
-        repos_list <- self$response(
-          paste0(
-            private$endpoints[["search"]],
-            "%22",
-            code,
-            "%22&per_page=100&page=",
-            page
-          )
-        )
-        if (length(repos_list) == 0) {
-          still_more_hits <- FALSE
-          break()
-        } else {
-          repos_list <- private$limit_search_to_files(
-            repos_list = repos_list,
-            files = settings$files
-          )
-          full_repos_list <- append(full_repos_list, repos_list)
-          page <- page + 1
-        }
-      }
-      full_repos_list <- full_repos_list %>%
+      full_repos_list <- private$search_for_code(
+        code = code,
+        org = org,
+        settings = settings
+      ) %>%
         private$map_search_into_repos() %>%
         private$pull_repos_languages()
       return(full_repos_list)
@@ -208,7 +200,7 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     },
 
     # Set search endpoint
-    set_search_endpoint = function(org) {
+    set_search_endpoint = function(org = NULL) {
       groups_search <- if (!private$scan_all) {
         private$set_groups_search_endpoint(org)
       } else {
@@ -236,6 +228,39 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
         private$pull_repos_languages(
           verbose = settings$verbose
         )
+      return(full_repos_list)
+    },
+
+    # Search for code
+    search_for_code = function(code, org = NULL, settings, page_max = 1e6) {
+      page <- 1
+      still_more_hits <- TRUE
+      full_repos_list <- list()
+      private$set_search_endpoint(org)
+      if (!grepl("path:", code)) {
+        code <- paste0("%22", code, "%22")
+      }
+      while (still_more_hits | page < page_max) {
+        repos_list <- self$response(
+          paste0(
+            private$endpoints[["search"]],
+            code,
+            "&per_page=100&page=",
+            page
+          )
+        )
+        if (length(repos_list) == 0) {
+          still_more_hits <- FALSE
+          break()
+        } else {
+          repos_list <- private$limit_search_to_files(
+            repos_list = repos_list,
+            files = settings$files
+          )
+          full_repos_list <- append(full_repos_list, repos_list)
+          page <- page + 1
+        }
+      }
       return(full_repos_list)
     },
 
@@ -297,6 +322,41 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
     # A helper to get group's id
     get_group_id = function(project_group) {
       self$response(paste0(self$rest_api_url, "/groups/", project_group))[["id"]]
+    },
+
+    # Add file content to files search result
+    add_file_content = function(files_search_result, filename) {
+      purrr::map(files_search_result, function(file_data) {
+        repo_data <- self$response(
+          paste0(
+            private$endpoints$projects,
+            file_data$project_id
+          )
+        )
+        def_branch <- repo_data[["default_branch"]]
+        file_data <- tryCatch({
+          self$response(
+            paste0(
+              private$endpoints$projects,
+              file_data$project_id,
+              "/repository/files/",
+              filename,
+              "?ref=",
+              def_branch
+            )
+          )
+        }, error = function(e) {
+          NULL
+        })
+        if (!is.null(file_data)) {
+          file_data$repo_name <- repo_data$path
+          file_data$repo_fullname <- repo_data$path_with_namespace
+          file_data$repo_id <- repo_data$id
+          file_data$repo_url <- repo_data$web_url
+        }
+        return(file_data)
+      }, .progress = glue::glue("Adding file [{filename}] info...")) %>%
+        purrr::discard(is.null)
     }
   )
 )

--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -241,7 +241,7 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
         code <- paste0("%22", code, "%22")
       }
       while (still_more_hits | page < page_max) {
-        repos_list <- self$response(
+        search_result <- self$response(
           paste0(
             private$endpoints[["search"]],
             code,
@@ -249,12 +249,12 @@ EngineRestGitLab <- R6::R6Class("EngineRestGitLab",
             page
           )
         )
-        if (length(repos_list) == 0) {
+        if (length(search_result) == 0) {
           still_more_hits <- FALSE
           break()
         } else {
           repos_list <- private$limit_search_to_files(
-            repos_list = repos_list,
+            search_result = search_result,
             files = settings$files
           )
           full_repos_list <- append(full_repos_list, repos_list)

--- a/R/GQLQueryGitLab.R
+++ b/R/GQLQueryGitLab.R
@@ -142,28 +142,6 @@ GQLQueryGitLab <- R6::R6Class("GQLQueryGitLab",
       )
     },
 
-    #' @description Prepare query to get files in a standard filepath from
-    #'   GitLab repositories.
-    #' @return A query.
-    files_from_repo = function(){
-      'query GetFilesFromRepo($file_paths: [String!]!, $project_path: ID!) {
-              project(fullPath: $project_path) {
-                name
-                id
-                webUrl
-                repository {
-                  blobs(paths: $file_paths) {
-                    nodes {
-                      name
-                      rawBlob
-                      size
-                    }
-                  }
-                }
-              }
-          }'
-    },
-
     #' @description Prepare query to get releases from GitHub repositories.
     #' @return A query.
     releases_from_repo = function() {

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -61,6 +61,10 @@ GitHost <- R6::R6Class("GitHost",
                             verbose = TRUE,
                             settings) {
       private$set_verbose(verbose)
+      if (private$scan_all && is.null(private$orgs)) {
+        cli::cli_alert_info("[{private$host_name}][Engine:{cli::col_yellow('GraphQL')}] Pulling all organizations...")
+        private$orgs <- private$engines$graphql$pull_orgs()
+      }
       if (is.null(until)) {
         until <- Sys.time()
       }
@@ -102,6 +106,10 @@ GitHost <- R6::R6Class("GitHost",
 
     #' Iterator over pulling release logs from engines
     pull_release_logs = function(since, until, verbose, settings) {
+      if (private$scan_all && is.null(private$orgs)) {
+        cli::cli_alert_info("[{private$host_name}][Engine:{cli::col_yellow('GraphQL')}] Pulling all organizations...")
+        private$orgs <- private$engines$graphql$pull_orgs()
+      }
       until <- until %||% Sys.time()
       release_logs_table <- purrr::map(private$orgs, function(org) {
         release_logs_table_org <- NULL

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -618,7 +618,8 @@ GitHost <- R6::R6Class("GitHost",
       files_table <- rest_engine$pull_files(
         files = file_path
       ) %>%
-        private$prepare_files_table_from_rest()
+        private$prepare_files_table_from_rest() %>%
+        private$add_repo_api_url()
       return(files_table)
     }
   )

--- a/R/GitHostGitHub.R
+++ b/R/GitHostGitHub.R
@@ -292,6 +292,41 @@ GitHostGitHub <- R6::R6Class("GitHostGitHub",
       return(files_table)
     },
 
+    # Prepare files table from REST API.
+    prepare_files_table_from_rest = function(files_list) {
+      files_table <- NULL
+      if (!is.null(files_list)) {
+        files_table <- purrr::map(files_list, function(file_data) {
+          repo_fullname <- private$get_repo_fullname(file_data$url)
+          org_repo <- stringr::str_split_1(repo_fullname, "/")
+          data.frame(
+            "repo_name" = org_repo[2],
+            "repo_id" = NA_character_,
+            "organization" = org_repo[1],
+            "file_path" = file_data$path,
+            "file_content" = file_data$content,
+            "file_size" = file_data$size,
+            "repo_url" = private$get_repo_url(file_data$url),
+            "api_url" = private$api_url
+          )
+        }) %>%
+          purrr::list_rbind()
+      }
+      return(files_table)
+    },
+
+    # Get repository full name
+    get_repo_fullname = function(file_url) {
+      stringr::str_remove_all(file_url,
+                              paste0(private$endpoints$repositories, "/")) %>%
+        stringr::str_replace_all("/contents.*", "")
+    },
+
+    # Get repository url
+    get_repo_url = function(repo_fullname) {
+      paste0(private$endpoints$repositories, "/", repo_fullname)
+    },
+
     # Prepare releases table.
     prepare_releases_table = function(releases_response, org, date_from, date_until) {
       if (!is.null(releases_response)) {

--- a/R/GitHostGitHub.R
+++ b/R/GitHostGitHub.R
@@ -279,8 +279,7 @@ GitHostGitHub <- R6::R6Class("GitHostGitHub",
               "file_path" = file,
               "file_content" = repository$object$text,
               "file_size" = repository$object$byteSize,
-              "repo_url" = repository$url,
-              "api_url" = private$graphql_api_url
+              "repo_url" = repository$url
             )
           }) %>%
             purrr::list_rbind()
@@ -306,8 +305,7 @@ GitHostGitHub <- R6::R6Class("GitHostGitHub",
             "file_path" = file_data$path,
             "file_content" = file_data$content,
             "file_size" = file_data$size,
-            "repo_url" = private$get_repo_url(file_data$url),
-            "api_url" = private$api_url
+            "repo_url" = private$get_repo_url(file_data$url)
           )
         }) %>%
           purrr::list_rbind()

--- a/R/GitHostGitLab.R
+++ b/R/GitHostGitLab.R
@@ -313,8 +313,7 @@ GitHostGitLab <- R6::R6Class("GitHostGitLab",
               "file_path" = file$name,
               "file_content" = file$rawBlob,
               "file_size" = as.integer(file$size),
-              "repo_url" = project$webUrl,
-              "api_url" = private$graphql_api_url
+              "repo_url" = project$webUrl
             )
           }) %>%
             purrr::list_rbind()
@@ -340,8 +339,7 @@ GitHostGitLab <- R6::R6Class("GitHostGitLab",
             "file_path" = file_data$file_path,
             "file_content" = file_data$content,
             "file_size" = file_data$size,
-            "repo_url" = file_data$repo_url,
-            "api_url" = private$api_url
+            "repo_url" = file_data$repo_url
           )
         }) %>%
           purrr::list_rbind() %>%

--- a/R/GitHostGitLab.R
+++ b/R/GitHostGitLab.R
@@ -326,6 +326,30 @@ GitHostGitLab <- R6::R6Class("GitHostGitLab",
       return(files_table)
     },
 
+    # Prepare files table from REST API.
+    prepare_files_table_from_rest = function(files_list) {
+      files_table <- NULL
+      if (!is.null(files_list)) {
+        files_table <- purrr::map(files_list, function(file_data) {
+          org_repo <- stringr::str_split_1(file_data$repo_fullname, "/")
+          org <- paste0(org_repo[1:(length(org_repo) - 1)], collapse = "/")
+          data.frame(
+            "repo_name" = file_data$repo_name,
+            "repo_id" = as.character(file_data$repo_id),
+            "organization" = org,
+            "file_path" = file_data$file_path,
+            "file_content" = file_data$content,
+            "file_size" = file_data$size,
+            "repo_url" = file_data$repo_url,
+            "api_url" = private$api_url
+          )
+        }) %>%
+          purrr::list_rbind() %>%
+          unique()
+      }
+      return(files_table)
+    },
+
     # Prepare releases table.
     prepare_releases_table = function(releases_response, org, date_from, date_until) {
       if (length(releases_response) > 0) {

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -518,9 +518,7 @@ GitStats <- R6::R6Class("GitStats",
       purrr::map(private$hosts, function(host) {
         host$pull_files(
           file_path = file_path,
-          pulled_repos = private$storage[["repositories"]],
-          verbose = verbose,
-          settings = private$settings
+          verbose = verbose
         )
       }) %>%
         purrr::list_rbind()

--- a/R/message_handler.R
+++ b/R/message_handler.R
@@ -4,10 +4,14 @@ show_message <- function(host,
                          scope = NULL,
                          code = NULL,
                          information) {
+  msg_graphql <- cli::col_yellow('GraphQl')
+  msg_rest <- cli::col_green('REST')
   engine_msg <- if (engine == "graphql") {
-    cli::col_yellow('GraphQl')
+    msg_graphql
   } else if (engine == "rest") {
-    cli::col_green('REST')
+    msg_rest
+  } else if (engine == "both") {
+    paste0(msg_rest, "&",msg_graphql)
   }
   message <- if (is.null(scope)) {
     glue::glue("[Host:{host}][Engine:{engine_msg}] {information}...")

--- a/tests/testthat/_snaps/01-GQLQueryGitLab.md
+++ b/tests/testthat/_snaps/01-GQLQueryGitLab.md
@@ -19,13 +19,6 @@
     Output
       [1] "query GetFilesByOrg($org: ID!, $file_paths: [String!]!) {\n            group(fullPath: $org) {\n              projects(first: 100) {\n                count\n                pageInfo {\n                  hasNextPage\n                  endCursor\n                }\n                edges {\n                  node {\n                    name\n                    id\n                    webUrl\n                    repository {\n                      blobs(paths: $file_paths) {\n                        nodes {\n                          name\n                          rawBlob\n                          size\n                        }\n                      }\n                    }\n                  }\n                }\n              }\n            }\n          }"
 
----
-
-    Code
-      gl_repo_files_query
-    Output
-      [1] "query GetFilesFromRepo($file_paths: [String!]!, $project_path: ID!) {\n              project(fullPath: $project_path) {\n                name\n                id\n                webUrl\n                repository {\n                  blobs(paths: $file_paths) {\n                    nodes {\n                      name\n                      rawBlob\n                      size\n                    }\n                  }\n                }\n              }\n          }"
-
 # releases query is built properly
 
     Code

--- a/tests/testthat/_snaps/04-GitHost.md
+++ b/tests/testthat/_snaps/04-GitHost.md
@@ -30,15 +30,14 @@
 # `pull_files()` pulls files in the table format
 
     Code
-      gh_files_table <- test_host$pull_files(file_path = "LICENSE", settings = test_settings)
+      gh_files_table <- test_host$pull_files(file_path = "LICENSE")
     Message
       i [Host:GitHub][Engine:GraphQl][Scope:r-world-devs] Pulling files: [LICENSE]...
 
 ---
 
     Code
-      gl_files_table <- test_host_gitlab$pull_files(file_path = "README.md",
-        settings = test_settings)
+      gl_files_table <- test_host_gitlab$pull_files(file_path = "README.md")
     Message
       i [Host:GitLab][Engine:GraphQl][Scope:mbtests] Pulling files: [README.md]...
 
@@ -62,7 +61,7 @@
 
     Code
       gl_files_table <- test_host_gitlab$pull_files(file_path = c("meta_data.yaml",
-        "README.md"), settings = test_settings)
+        "README.md"))
     Message
       i [Host:GitLab][Engine:GraphQl][Scope:mbtests] Pulling files: [meta_data.yaml, README.md]...
 

--- a/tests/testthat/_snaps/07-GitStats.md
+++ b/tests/testthat/_snaps/07-GitStats.md
@@ -50,18 +50,3 @@
        Repositories: [0] 
       Storage: <no tables in storage>
 
-# GitStats prints with storage
-
-    Code
-      test_gitstats
-    Output
-      A GitStats object for 2 hosts: 
-      Hosts: https://api.github.com, https://gitlab.com/api/v4
-      Scanning scope: 
-       Organizations: [2] r-world-devs, mbtests
-       Repositories: [0] 
-      Storage: 
-       Repositories: 17 
-       Commits: 24 [date range: 2023-06-15 - 2023-06-30]
-       R_package_usage: 11 [package: purrr]
-

--- a/tests/testthat/helper-expect-tables.R
+++ b/tests/testthat/helper-expect-tables.R
@@ -65,13 +65,9 @@ expect_files_table <- function(files_object) {
     files_object,
     c("repo_name", "repo_id", "organization",
       "file_path", "file_content", "file_size",
-      "repo_url", "api_url")
+      "repo_url")
   )
   expect_type(files_object$file_size, "integer")
-  expect_type(files_object$api_url, "character")
-  expect_true(
-    all(purrr::map_lgl(files_object$api_url, ~ grepl("api", .)))
-  )
   expect_gt(nrow(files_object), 0)
 }
 

--- a/tests/testthat/helper-expect-tables.R
+++ b/tests/testthat/helper-expect-tables.R
@@ -59,13 +59,13 @@ expect_users_table <- function(get_user_object, one_user = FALSE) {
   }
 }
 
-expect_files_table <- function(files_object) {
+expect_files_table <- function(files_object, add_col = NULL) {
   expect_s3_class(files_object, "data.frame")
   expect_named(
     files_object,
     c("repo_name", "repo_id", "organization",
       "file_path", "file_content", "file_size",
-      "repo_url")
+      "repo_url", add_col)
   )
   expect_type(files_object$file_size, "integer")
   expect_gt(nrow(files_object), 0)

--- a/tests/testthat/test-01-GQLQueryGitLab.R
+++ b/tests/testthat/test-01-GQLQueryGitLab.R
@@ -24,11 +24,6 @@ test_that("file queries are built properly", {
   expect_snapshot(
     gl_files_query
   )
-  gl_repo_files_query <-
-    test_gqlquery_gl$files_from_repo()
-  expect_snapshot(
-    gl_repo_files_query
-  )
 })
 
 test_that("releases query is built properly", {

--- a/tests/testthat/test-04-GitHost.R
+++ b/tests/testthat/test-04-GitHost.R
@@ -147,7 +147,7 @@ test_that("`pull_files()` pulls files in the table format", {
       file_path = "LICENSE"
     )
   )
-  expect_files_table(gh_files_table)
+  expect_files_table(gh_files_table, add_col = "api_url")
   test_mocker$cache(gh_files_table)
 })
 
@@ -245,7 +245,7 @@ test_that("`pull_files()` pulls files in the table format", {
       file_path = "README.md"
     )
   )
-  expect_files_table(gl_files_table)
+  expect_files_table(gl_files_table, add_col = "api_url")
   test_mocker$cache(gl_files_table)
 })
 
@@ -255,7 +255,7 @@ test_that("`pull_files()` pulls two files in the table format", {
       file_path = c("meta_data.yaml", "README.md")
     )
   )
-  expect_files_table(gl_files_table)
+  expect_files_table(gl_files_table, add_col = "api_url")
   expect_true(
     all(c("meta_data.yaml", "README.md") %in% gl_files_table$file_path)
   )

--- a/tests/testthat/test-04-GitHost.R
+++ b/tests/testthat/test-04-GitHost.R
@@ -144,8 +144,7 @@ test_that("`pull_commits()` retrieves commits in the table format", {
 test_that("`pull_files()` pulls files in the table format", {
   expect_snapshot(
     gh_files_table <- test_host$pull_files(
-      file_path = "LICENSE",
-      settings = test_settings
+      file_path = "LICENSE"
     )
   )
   expect_files_table(gh_files_table)
@@ -243,8 +242,7 @@ test_host_gitlab <- create_gitlab_testhost(orgs = "mbtests")
 test_that("`pull_files()` pulls files in the table format", {
   expect_snapshot(
     gl_files_table <- test_host_gitlab$pull_files(
-      file_path = "README.md",
-      settings = test_settings
+      file_path = "README.md"
     )
   )
   expect_files_table(gl_files_table)
@@ -254,8 +252,7 @@ test_that("`pull_files()` pulls files in the table format", {
 test_that("`pull_files()` pulls two files in the table format", {
   expect_snapshot(
     gl_files_table <- test_host_gitlab$pull_files(
-      file_path = c("meta_data.yaml", "README.md"),
-      settings = test_settings
+      file_path = c("meta_data.yaml", "README.md")
     )
   )
   expect_files_table(gl_files_table)

--- a/tests/testthat/test-05-GitHostGitHub.R
+++ b/tests/testthat/test-05-GitHostGitHub.R
@@ -183,7 +183,8 @@ test_that("pull_files for GitHub works", {
     )
   )
   expect_files_table(
-    gh_files_table
+    gh_files_table,
+    add_col = "api_url"
   )
 })
 

--- a/tests/testthat/test-05-GitHostGitHub.R
+++ b/tests/testthat/test-05-GitHostGitHub.R
@@ -179,8 +179,7 @@ test_that("pull_commits for GitHub works", {
 test_that("pull_files for GitHub works", {
   suppressMessages(
     gh_files_table <- test_host$pull_files(
-      file_path = "DESCRIPTION",
-      settings = test_settings
+      file_path = "DESCRIPTION"
     )
   )
   expect_files_table(

--- a/tests/testthat/test-05-GitHostGitLab.R
+++ b/tests/testthat/test-05-GitHostGitLab.R
@@ -109,8 +109,7 @@ test_that("pull_commits for GitLab works with repos implied", {
 test_that("pull_files for GitLab works", {
   suppressMessages(
     gl_files_table <- test_host$pull_files(
-      file_path = "meta_data.yaml",
-      settings = test_settings
+      file_path = "meta_data.yaml"
     )
   )
   expect_files_table(

--- a/tests/testthat/test-05-GitHostGitLab.R
+++ b/tests/testthat/test-05-GitHostGitLab.R
@@ -113,6 +113,6 @@ test_that("pull_files for GitLab works", {
     )
   )
   expect_files_table(
-    gl_files_table
+    gl_files_table, add_col = "api_url"
   )
 })

--- a/tests/testthat/test-07-GitStats.R
+++ b/tests/testthat/test-07-GitStats.R
@@ -146,13 +146,3 @@ test_that("get_release_logs works as expected", {
   )
   expect_releases_table(release_logs)
 })
-
-test_that("GitStats prints with storage", {
-  test_gitstats <- create_test_gitstats(
-    hosts = 2,
-    inject_repos = "repos_table",
-    inject_commits = "commits_table",
-    inject_package_usage = "R_package_usage"
-  )
-  expect_snapshot(test_gitstats)
-})

--- a/tests/testthat/test-07-GitStats.R
+++ b/tests/testthat/test-07-GitStats.R
@@ -93,7 +93,7 @@ test_that("get_files works properly", {
     verbose = FALSE
   )
   expect_files_table(
-    files_table
+    files_table, add_col = "api_url"
   )
   test_mocker$cache(files_table)
 })


### PR DESCRIPTION
Hi @Cotau `get_files()` for whole hosts should now work faster. For GitLab it is still slower than for GitHub (but not as slow as before, as it makes use of Search API, instead of iteration over all organizations), as it pulls some repo data to accomplish info in files table.