### PR TITLE
Fix setting default tokens when verbose mode is `FALSE` and fix checks for GitLab token scopes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
     person(given = "Matt", family = "Secrest", email = "secrestm@gene.com", role = "aut")
   )
 Description: Obtain statistics in a standardized way from multiple 'Git' services: 'GitHub' and 'GitLab' for the time-being. 
-    Its main purpose is to help teams, whose activities are spread across multiple git platforms, get their repository metadata 
+    Its main purpose is to help teams, whose activities are spread across multiple 'Git' platforms, get their repository metadata 
     in a standardized way from all these platforms.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GitStats
-Title: Get Statistics from 'GitHub' and 'GitLab'
+Title: Standardized Git Repository Statistics
 Version: 2.1.1.9000
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
@@ -7,9 +7,9 @@ Authors@R: c(
     person(given = "Karolina", family = "Marcinkowska", email = "karolina_marcinkowska@onet.pl", role = "aut"),
     person(given = "Matt", family = "Secrest", email = "secrestm@gene.com", role = "aut")
   )
-Description: Obtain statistics in a standardized way from multiple 'Git' services: 'GitHub' and 'GitLab' for the time-being. 
-    Its main purpose is to help teams, whose activities are spread across multiple 'Git' platforms, get their repository metadata 
-    in a standardized way from all these platforms.
+Description: Obtain standardized statistics from multiple 'Git' services, including 'GitHub' and 'GitLab'. 
+    Designed to be 'Git' service-agnostic, this package assists teams with activities spread across various 
+    'Git' platforms by providing a unified way to access repository metadata.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GitStats
 Title: Get Statistics from 'GitHub' and 'GitLab'
-Version: 2.1.1
+Version: 2.1.1.9000
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
     person(given = "Kamil", family = "Koziej", email = "koziej.k@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # GitStats (development version)
 
+- Fixed setting default tokens when `verbose` mode is set to `FALSE` ([#525](https://github.com/r-world-devs/GitStats/issues/525)) and fixed checking token scopes for GitLab ([#526](https://github.com/r-world-devs/GitStats/issues/526)).
+
 # GitStats 2.1.1
 
 This is a patch release which introduces some improvements in `get_R_package_usage()` on speed and possibility to pull at once data on multiple R packages, new `get_storage()` function and some fixes for checking token scopes and setting hosts.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# GitStats (development version)
+
 # GitStats 2.1.1
 
 This is a patch release which introduces some improvements in `get_R_package_usage()` on speed and possibility to pull at once data on multiple R packages, new `get_storage()` function and some fixes for checking token scopes and setting hosts.

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -516,8 +516,10 @@ GitHost <- R6::R6Class(
     set_default_token = function(verbose) {
       primary_token_name <- private$token_name
       token <- Sys.getenv(primary_token_name)
-      if (private$test_token(token) && verbose) {
-        cli::cli_alert_info("Using PAT from {primary_token_name} envar.")
+      if (private$test_token(token)) {
+        if (verbose) {
+          cli::cli_alert_info("Using PAT from {primary_token_name} envar.")
+        }
       } else {
         pat_names <- names(Sys.getenv()[grepl(primary_token_name, names(Sys.getenv()))])
         possible_tokens <- pat_names[pat_names != primary_token_name]

--- a/R/GitHostGitLab.R
+++ b/R/GitHostGitLab.R
@@ -184,27 +184,9 @@ GitHostGitLab <- R6::R6Class("GitHostGitLab",
       )
     },
 
-    # check token scopes
-    # response parameter only for need of super method
+    # An empty method to fullfill call from super class.
     check_token_scopes = function(response = NULL, token) {
-      private$token_scopes <- try({
-        httr2::request(private$endpoints$tokens) %>%
-          httr2::req_headers("Authorization" = paste0("Bearer ", token)) %>%
-          httr2::req_perform() %>%
-          httr2::resp_body_json() %>%
-          purrr::keep(~ .$active) %>%
-          purrr::map(function(pat) {
-            data.frame(scopes = unlist(pat$scopes), date = pat$last_used_at)
-          }) %>%
-          purrr::list_rbind() %>%
-          dplyr::filter(
-            date == max(date)
-          ) %>%
-          dplyr::select(scopes) %>%
-          unlist()
-      },
-      silent = TRUE)
-      any(private$access_scopes %in% private$token_scopes)
+      TRUE
     },
 
     # Add `api_url` column to table.

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,13 +33,15 @@ With GitStats you can pull git data in a uniform way (table format) from GitHub 
 
 ## Installation
 
-```r
 From CRAN:
 
+```r
 install.packages("GitStats")
+```
 
 Or development version:
 
+```r
 devtools::install_github("r-world-devs/GitStats")
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ GitHub and GitLab. For the time-being you can get data on:
 
 ## Installation
 
-``` r
 From CRAN:
 
+``` r
 install.packages("GitStats")
+```
 
 Or development version:
 
+``` r
 devtools::install_github("r-world-devs/GitStats")
 ```
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -151,6 +151,30 @@ test_that("`test_token` works properly", {
   )
 })
 
+test_that("`test_token` works properly", {
+  skip_on_cran()
+  expect_true(
+    gitlab_testhost_priv$test_token(Sys.getenv("GITLAB_PAT_PUBLIC"))
+  )
+  expect_false(
+    gitlab_testhost_priv$test_token("false_token")
+  )
+})
+
+test_that("`check_token_scopes` works for GitHub", {
+  skip_on_cran()
+  github_pat <- Sys.getenv("GITHUB_PAT")
+  github_response <- httr2::request("https://api.github.com") |>
+    httr2::req_headers("Authorization" = paste0("Bearer ", github_pat)) |>
+    httr2::req_perform()
+  expect_true(
+    github_testhost_priv$check_token_scopes(
+      response = github_response,
+      token = github_pat
+    )
+  )
+})
+
 test_that("`set_default_token` sets default token for GitLab", {
   skip_on_cran()
   expect_snapshot(

--- a/tests/testthat/test-set_host.R
+++ b/tests/testthat/test-set_host.R
@@ -173,3 +173,20 @@ test_that("Error pops out when `org` does not exist", {
     error = TRUE
   )
 })
+
+test_that("Setting verbose for set_*_host() to FALSE works fine", {
+  expect_no_error(
+    create_gitstats() %>%
+      set_github_host(
+        orgs = c("openpharma", "r-world-devs"),
+        verbose = FALSE
+      )
+  )
+  expect_no_error(
+    create_gitstats() %>%
+      set_gitlab_host(
+        orgs = "mbtests",
+        verbose = FALSE
+      )
+  )
+})


### PR DESCRIPTION
Closes #525 #526

This PR addresses two issues:

- fixing setting default tokens when verbose mode is `FALSE` and 
- fixing checks for GitLab token scopes.