### PR TITLE
fix map from 1 to zero iterations if orgs_count is less than 100

### DIFF
--- a/R/EngineRestGitLab.R
+++ b/R/EngineRestGitLab.R
@@ -18,7 +18,7 @@ EngineRestGitLab <- R6::R6Class(
       if (verbose) {
         cli::cli_alert("[Host:GitLab][Engine:{cli::col_green('REST')}] Pulling organizations...")
       }
-      iterations_number <- round(orgs_count / 100)
+      iterations_number <- ceiling(orgs_count / 100)
       orgs_list <- purrr::map(1:iterations_number, function(page) {
         self$response(
           paste0(


### PR DESCRIPTION
If `orgs_count` is less than 100, `iterations_number` rounds to 0, causing `purrr::map(1:0, ...)` during pagination of orgs from the API.  This causes two API calls: the first requesting page 1 (which returns expected results), and the second requesting page 0 (which returns page 1 again).  

Changing round() to ceiling() rounds up to the nearest integer, making only one API call if the number of orgs is less than 100.  