### PR TITLE
Optimize parsing REST search response with GraphQL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GitStats
 Title: Standardized Git Repository Data
-Version: 2.3.5.9009
+Version: 2.3.5.9010
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
     person(given = "Kamil", family = "Koziej", email = "koziej.k@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,10 @@
 - Fixed `depth` parameter in `get_files()` - previously `0` and `1` value returned same output, i.e. files from `root`. Now it works the way as explained in function documentation - value `0` returns files from the `root` and value `1` goes 1 level deeper ([#663](https://github.com/r-world-devs/GitStats/issues/663)).
 - Added `language` parameter to `get_repos()` function to pull repositories only with defined language ([#654](https://github.com/r-world-devs/GitStats/issues/654)). For GitHub Search API it translates into language query, whereas in other cases the repositories output is simply filtered by the given language.
 - Introduced new `repo_fullpath` column, which replaced `fullname` in output of `get_repos()`. The `fullname` column was flawed in case of GitLab repositories as it was created out of repository `name` with `organization`. In case of GitLab repository `name` (which is more of a user friendly label) differs from repository `path` (which is in the `URL`), unlike in GitHub where repository `name` is repository `path` ([#659](https://github.com/r-world-devs/GitStats/issues/659)). `repo_name` column for GitLab repositories now mirrors repository `path`.
-- Handled `GraphQL Internal Server Error` with switching to `REST API` when parsing search response to repositories output ([#666](https://github.com/r-world-devs/GitStats/issues/666)).
 - Enhanced `verbose` role to control displaying of response error statuses ([#669](https://github.com/r-world-devs/GitStats/issues/669)).
 - Improved code for searching code blobs, so `get_repos()` does not fail when user passes text, e.g. with spaces to the `with_code` parameter ([#673](https://github.com/r-world-devs/GitStats/issues/673)).
 - Standardized `repo_id` column in `get_repos()` and `get_files()` outputs for GitLab hosts - it consists now only of digits formatted as a `character` ([#675](https://github.com/r-world-devs/GitStats/issues/675)).
+- Optimized parsing search response to repositories response ([#679](https://github.com/r-world-devs/GitStats/issues/679)).
 
 # GitStats 2.3.5
 

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -1126,38 +1126,10 @@ GitHost <- R6::R6Class(
         repos_ids <- private$get_repos_ids(search_response)
         api_engine <- private$engines$graphql
         if (verbose) cli::cli_alert("Parsing search response with GraphQL...")
-        if (!is.null(org)) {
-          owner_type <- attr(org, "type") %||% "organization"
-          repos_from_org <- api_engine$get_repos_from_org(
-            org = org,
-            owner_type = owner_type,
-            verbose = verbose
-          )
-          if (!inherits(repos_from_org, "graphql_error")) {
-            repos_response <- repos_from_org |>
-              purrr::keep(function(repo) {
-                if (is.null(repo$node)) {
-                  repo_node <- repo
-                } else {
-                  repo_node <- repo$node
-                }
-                any(purrr::map_lgl(repos_ids, ~ grepl(., repo_node$repo_id)))
-              })
-          } else {
-            api_engine <- private$engines$rest
-            if (verbose) cli::cli_alert_info("Switching to REST API... it may take longer \U1F553")
-            repos_from_org <- api_engine$get_repos_from_org(org = org)
-            repos_response <- repos_from_org |>
-              purrr::keep(function(repo) {
-                any(purrr::map_lgl(repos_ids, ~ grepl(., repo$id)))
-              })
-          }
-        } else {
-          repos_response <- api_engine$get_repos(
-            repos_ids = repos_ids,
-            verbose = verbose
-          )
-        }
+        repos_response <- api_engine$get_repos(
+          repos_ids = repos_ids,
+          verbose = verbose
+        )
         if (output != "raw") {
           repos_output <- repos_response |>
             api_engine$prepare_repos_table(

--- a/tests/testthat/_snaps/01-get_repos-GitHub.md
+++ b/tests/testthat/_snaps/01-get_repos-GitHub.md
@@ -54,19 +54,6 @@
     Message
       > [Host:GitHub][Engine:REST][Scope:] Pulling repositories...
 
-# `get_repos_with_code_from_host()` pulls raw response
-
-    Code
-      repos_with_code_from_host_raw <- github_testhost_priv$
-        get_repos_with_code_from_host(code = "shiny", in_files = c("DESCRIPTION",
-        "NAMESPACE"), output = "raw", verbose = TRUE)
-    Message
-      > [Host:GitHub][Engine:REST] Pulling repositories...
-      > Searching for code [shiny]...
-      x HTTP 401 Unauthorized.
-      > Searching for code [shiny]...
-      x HTTP 401 Unauthorized.
-
 # get_repos_from_repos works
 
     Code

--- a/tests/testthat/_snaps/01-get_repos-GitHub.md
+++ b/tests/testthat/_snaps/01-get_repos-GitHub.md
@@ -28,16 +28,6 @@
     Message
       > Parsing search response with GraphQL...
 
-# parse_search_response turns to REST when first attempt returns error
-
-    Code
-      gh_repos_by_code_table <- github_testhost_priv$parse_search_response(
-        search_response = test_mocker$use("gh_search_repos_for_code"), org = gh_org,
-        output = "raw", verbose = TRUE)
-    Message
-      > Parsing search response with GraphQL...
-      i Switching to REST API... it may take longer 🕓
-
 # `get_repos_with_code_from_orgs()` pulls raw response
 
     Code

--- a/tests/testthat/test-01-get_repos-GitHub.R
+++ b/tests/testthat/test-01-get_repos-GitHub.R
@@ -275,8 +275,8 @@ test_that("parse_search_response parses search response into repositories output
 test_that("parse_search_response parses search response into repositories output", {
   mockery::stub(
     github_testhost_priv$parse_search_response,
-    "api_engine$get_repos_from_org",
-    test_mocker$use("gh_repos_from_org")
+    "api_engine$get_repos",
+    test_mocker$use("gh_repos_by_ids")
   )
   gh_repos_by_code_table <- github_testhost_priv$parse_search_response(
     search_response = test_mocker$use("gh_search_repos_for_code"),
@@ -296,24 +296,6 @@ test_that("parse_search_response prints message", {
   )
   expect_snapshot(
     gh_repos_raw_output <- github_testhost_priv$parse_search_response(
-      search_response = test_mocker$use("gh_search_repos_for_code"),
-      org = gh_org,
-      output = "raw",
-      verbose = TRUE
-    )
-  )
-})
-
-test_that("parse_search_response turns to REST when first attempt returns error", {
-  internal_server_error <- list("repo" = list("id" = "1234"))
-  class(internal_server_error) <- c("graphql_error", "graphql_server_error")
-  mockery::stub(
-    github_testhost_priv$parse_search_response,
-    "api_engine$get_repos_from_org",
-    internal_server_error
-  )
-  expect_snapshot(
-    gh_repos_by_code_table <- github_testhost_priv$parse_search_response(
       search_response = test_mocker$use("gh_search_repos_for_code"),
       org = gh_org,
       output = "raw",

--- a/tests/testthat/test-01-get_repos-GitHub.R
+++ b/tests/testthat/test-01-get_repos-GitHub.R
@@ -401,22 +401,6 @@ test_that("`get_repos_with_code_from_repos()` works", {
 test_that("`get_repos_with_code_from_host()` pulls raw response", {
   mockery::stub(
     github_testhost_priv$get_repos_with_code_from_host,
-    "rest_engine$search_repos_for_code",
-    test_mocker$use("gh_search_repos_for_code")
-  )
-  expect_snapshot(
-    repos_with_code_from_host_raw <- github_testhost_priv$get_repos_with_code_from_host(
-      code = "shiny",
-      in_files = c("DESCRIPTION", "NAMESPACE"),
-      output = "raw",
-      verbose = TRUE
-    )
-  )
-})
-
-test_that("`get_repos_with_code_from_host()` pulls raw response", {
-  mockery::stub(
-    github_testhost_priv$get_repos_with_code_from_host,
     "rest_engine$search_for_code",
     test_mocker$use("gh_search_repos_for_code")
   )


### PR DESCRIPTION
First motivation was to speed up the process of getting repositories languages after GraphQL response failed on large amount of data and switched to REST which was very slow.

However, it occured, that GraphQL handler for getting response could be simplified with vectorized query approach (a `get_repos()` method instead of `get_repos_from_org()` in `GraphQLEngine` class) - the side effect of this simplification was no failure of GraphQL response after receiving large amount of data!

Thus, switching to REST, for the time being has been skipped.