### PR TITLE
Add CRAN status and downloads badges to README

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GitStats
 Title: Standardized Git Repository Data
-Version: 2.4.0.9007
+Version: 2.5.0
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
     person(given = "Kamil", family = "Koziej", email = "koziej.k@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # GitStats 2.5.0
 
+This release introduces external storage backends (PostgreSQL and SQLite) for persisting pulled data across sessions, and optional parallel processing via `mirai` for faster API calls. It also brings several performance improvements, including a faster file tree retrieval and optimized GitLab repository queries.
+
 - Added `add_languages` parameter to `get_repos()` (`TRUE` by default). When set to `FALSE`, languages data is excluded from the output and the GitLab REST languages API calls are skipped, speeding up the process.
 - Fixed `get_repos()` returning `NA` for `commit_sha` on archived GitLab projects. When the GraphQL API returns `null` for `lastCommit`, a REST Branches API fallback can now retrieve the SHA. Use `fill_empty_sha = TRUE` in `get_repos()` to enable this ([#746](https://github.com/r-world-devs/GitStats/issues/746)).
 - Added optional parallel processing for API calls via `mirai` package. Use `set_parallel()` to enable concurrent data fetching across repositories and organizations ([#736](https://github.com/r-world-devs/GitStats/issues/736)).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# GitStats 2.4.0.9000
+# GitStats 2.5.0
 
 - Fixed `get_repos()` returning `NA` for `commit_sha` on archived GitLab projects. When the GraphQL API returns `null` for `lastCommit`, a REST Branches API fallback can now retrieve the SHA. Use `fill_empty_sha = TRUE` in `get_repos()` to enable this ([#746](https://github.com/r-world-devs/GitStats/issues/746)).
 - Added optional parallel processing for API calls via `mirai` package. Use `set_parallel()` to enable concurrent data fetching across repositories and organizations ([#736](https://github.com/r-world-devs/GitStats/issues/736)).
@@ -9,7 +9,7 @@
 - Added `remove_postgres_storage()` and `remove_sqlite_storage()` to fully remove a database storage backend — the PostgreSQL variant drops the GitStats schema, the SQLite variant deletes the database file — and revert to local storage ([#759](https://github.com/r-world-devs/GitStats/issues/759)).
 - Added `get_storage_metadata()` to retrieve metadata (R classes, custom attributes, column types) for a stored table ([#748](https://github.com/r-world-devs/GitStats/issues/748)).
 - Fixed slow `get_repos()` for GitLab when specific repos are set. Previously, the `repos_by_user` GraphQL query searched the entire GitLab instance; now repos are queried directly by `fullPath` ([#750](https://github.com/r-world-devs/GitStats/issues/750)).
-- Sped up vignettes generation ([#504](https://github.com/r-world-devs/GitStats/issues/504)).
+- Sped up vignettes generation ([#504](https://github.com/r-world-devs/GitStats/issues/504), [@marcinkowskak](https://github.com/marcinkowskak)).
 
 # GitStats 2.4.0
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,6 +18,8 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![lifecycle](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![CRAN status](https://www.r-pkg.org/badges/version/GitStats)](https://CRAN.R-project.org/package=GitStats)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/GitStats)](https://CRAN.R-project.org/package=GitStats)
 [![R-CMD-check](https://github.com/r-world-devs/GitStats/workflows/R-CMD-check/badge.svg)](https://github.com/r-world-devs/GitStats/actions)
 [![Codecov test coverage](https://codecov.io/gh/r-world-devs/GitStats/branch/devel/graph/badge.svg)](https://app.codecov.io/gh/r-world-devs/GitStats?branch=devel)
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 <!-- badges: start -->
 
 [![lifecycle](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![CRAN
+status](https://www.r-pkg.org/badges/version/GitStats)](https://CRAN.R-project.org/package=GitStats)
+[![CRAN
+downloads](https://cranlogs.r-pkg.org/badges/grand-total/GitStats)](https://CRAN.R-project.org/package=GitStats)
 [![R-CMD-check](https://github.com/r-world-devs/GitStats/workflows/R-CMD-check/badge.svg)](https://github.com/r-world-devs/GitStats/actions)
 [![Codecov test
 coverage](https://codecov.io/gh/r-world-devs/GitStats/branch/devel/graph/badge.svg)](https://app.codecov.io/gh/r-world-devs/GitStats?branch=devel)

--- a/vignettes/store_data.Rmd
+++ b/vignettes/store_data.Rmd
@@ -8,11 +8,13 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
+has_tokens <- nzchar(Sys.getenv("GITHUB_PAT")) && nzchar(Sys.getenv("GITLAB_PAT_PUBLIC"))
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.width = 7,
-  fig.height = 4
+  fig.height = 4,
+  eval = has_tokens
 )
 ```
 


### PR DESCRIPTION
## Description

- Add CRAN version status and grand-total downloads badges to `README.Rmd` and `README.md`.
- Gate `store_data.Rmd` vignette evaluation on token availability. Chunks are skipped when `GITHUB_PAT` or `GITLAB_PAT_PUBLIC` are missing (e.g. on CRAN), preventing build failures. The pkgdown CI workflow already provides these secrets, so the site continues to render with real output.

## Related Issue(s)

Fixes #598

## How to test

1. Verify the two new badges (CRAN status, CRAN downloads) appear in the rendered README and link to `https://CRAN.R-project.org/package=GitStats`.
2. Run `R CMD check --as-cran` without `GITHUB_PAT` / `GITLAB_PAT_PUBLIC` set — the `store_data` vignette should build without errors.