### PR TITLE
Fix GitLab GraphQL complexity error when fetching repos by IDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GitStats
 Title: Standardized Git Repository Data
-Version: 2.5.0
+Version: 2.5.0.9000
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
     person(given = "Kamil", family = "Koziej", email = "koziej.k@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# GitStats (development version)
+
 # GitStats 2.5.0
 
 This release introduces external storage backends (PostgreSQL and SQLite) for persisting pulled data across sessions, and optional parallel processing via `mirai` for faster API calls. It also brings several performance improvements, including a faster file tree retrieval and optimized GitLab repository queries.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # GitStats (development version)
 
+- Fixed `get_repos()` with `with_code` failing for GitLab when the code search returns more than 1000 repositories. The GraphQL resolver rejects queries with too many IDs; `get_repos()` now detects this limit error and automatically batches the IDs ([#781](https://github.com/r-world-devs/GitStats/issues/781)).
+
 # GitStats 2.5.0
 
 This release introduces external storage backends (PostgreSQL and SQLite) for persisting pulled data across sessions, and optional parallel processing via `mirai` for faster API calls. It also brings several performance improvements, including a faster file tree retrieval and optimized GitLab repository queries.

--- a/R/EngineGraphQL.R
+++ b/R/EngineGraphQL.R
@@ -207,6 +207,10 @@ EngineGraphQL <- R6::R6Class(
       any(purrr::map_lgl(response$errors, ~ grepl("Internal server error", .$message)))
     },
 
+    is_limit_error = function(response) {
+      any(purrr::map_lgl(response$errors, ~ grepl("cannot accept more than", .$message)))
+    },
+
     set_graphql_error_class = function(response) {
       if (private$is_query_error(response)) {
         class(response) <- c(class(response), "graphql_error")
@@ -215,6 +219,9 @@ EngineGraphQL <- R6::R6Class(
         }
         if (private$is_complexity_error(response)) {
           class(response) <- c(class(response), "graphql_complexity_error")
+        }
+        if (private$is_limit_error(response)) {
+          class(response) <- c(class(response), "graphql_limit_error")
         }
         if (private$is_server_error(response)) {
           class(response) <- c(class(response), "graphql_server_error")

--- a/R/EngineGraphQLGitLab.R
+++ b/R/EngineGraphQLGitLab.R
@@ -135,6 +135,19 @@ EngineGraphQLGitLab <- R6::R6Class(
             full_repos_list <- repos_response
             break
           }
+          if (inherits(repos_response, "graphql_complexity_error")) {
+            if (verbose) {
+              cli::cli_alert_warning("GraphQL complexity error when pulling repos by IDs ({length(repos_ids)} repos).")
+              cli::cli_alert_info(
+                cli::col_br_cyan("I will pull repos in batches.")
+              )
+            }
+            full_repos_list <- private$get_repos_in_batches(
+              repos_ids = repos_ids,
+              verbose = verbose
+            )
+            return(full_repos_list)
+          }
           repos_response <- private$get_repos_page(
             projects_ids = paste0("gid://gitlab/Project/", repos_ids),
             type = "projects",
@@ -547,6 +560,43 @@ EngineGraphQLGitLab <- R6::R6Class(
         )
       }
       return(response)
+    },
+
+    get_repos_in_batches = function(repos_ids, batch_size = 50, verbose) {
+      batches <- split(repos_ids, ceiling(seq_along(repos_ids) / batch_size))
+      full_repos_list <- list()
+      for (batch in batches) {
+        next_page <- TRUE
+        repo_cursor <- ""
+        while (next_page) {
+          repos_response <- private$get_repos_page(
+            projects_ids = paste0("gid://gitlab/Project/", batch),
+            type = "projects",
+            repo_cursor = repo_cursor,
+            verbose = verbose
+          )
+          if (inherits(repos_response, "graphql_error")) {
+            if (inherits(repos_response, "graphql_no_fields_error")) {
+              return(repos_response)
+            }
+            break
+          }
+          core_response <- repos_response$data$projects
+          repos_list <- core_response$edges
+          next_page <- core_response$pageInfo$hasNextPage
+          if (is.null(next_page)) next_page <- FALSE
+          if (is.null(repos_list)) repos_list <- list()
+          if (length(repos_list) == 0) next_page <- FALSE
+          if (next_page) {
+            repo_cursor <- core_response$pageInfo$endCursor
+          } else {
+            repo_cursor <- ""
+          }
+          full_repos_list <- append(full_repos_list, repos_list)
+        }
+      }
+      full_repos_list <- private$handle_graphql_error(full_repos_list, verbose)
+      return(full_repos_list)
     },
 
     get_repo_name_from_url = function(web_url) {

--- a/R/EngineGraphQLGitLab.R
+++ b/R/EngineGraphQLGitLab.R
@@ -135,9 +135,9 @@ EngineGraphQLGitLab <- R6::R6Class(
             full_repos_list <- repos_response
             break
           }
-          if (inherits(repos_response, "graphql_complexity_error")) {
+          if (inherits(repos_response, "graphql_limit_error")) {
             if (verbose) {
-              cli::cli_alert_warning("GraphQL complexity error when pulling repos by IDs ({length(repos_ids)} repos).")
+              cli::cli_alert_warning("GraphQL limit error when pulling repos by IDs ({length(repos_ids)} repos).")
               cli::cli_alert_info(
                 cli::col_br_cyan("I will pull repos in batches.")
               )

--- a/tests/testthat/_snaps/01-get_repos-GitLab.md
+++ b/tests/testthat/_snaps/01-get_repos-GitLab.md
@@ -35,7 +35,7 @@
       gitlab_repos <- test_graphql_gitlab$get_repos(repos_ids = c("test_id_1",
         "test_id_2"), verbose = TRUE)
     Message
-      ! GraphQL complexity error when pulling repos by IDs (2 repos).
+      ! GraphQL limit error when pulling repos by IDs (2 repos).
       i I will pull repos in batches.
 
 # `search_for_code()` works

--- a/tests/testthat/_snaps/01-get_repos-GitLab.md
+++ b/tests/testthat/_snaps/01-get_repos-GitLab.md
@@ -32,13 +32,11 @@
 # get_repos prints messages when falling back to batching
 
     Code
-      test_graphql_gitlab$get_repos(repos_ids = c("test_id_1", "test_id_2"),
-        verbose = TRUE)
+      gitlab_repos <- test_graphql_gitlab$get_repos(repos_ids = c("test_id_1",
+        "test_id_2"), verbose = TRUE)
     Message
       ! GraphQL complexity error when pulling repos by IDs (2 repos).
       i I will pull repos in batches.
-
----
 
 # `search_for_code()` works
 

--- a/tests/testthat/_snaps/01-get_repos-GitLab.md
+++ b/tests/testthat/_snaps/01-get_repos-GitLab.md
@@ -29,6 +29,17 @@
       i Your GraphQL does not recognize [count and languages] fields.
       ! Check version of your GitLab.
 
+# get_repos prints messages when falling back to batching
+
+    Code
+      test_graphql_gitlab$get_repos(repos_ids = c("test_id_1", "test_id_2"),
+        verbose = TRUE)
+    Message
+      ! GraphQL complexity error when pulling repos by IDs (2 repos).
+      i I will pull repos in batches.
+
+---
+
 # `search_for_code()` works
 
     Code

--- a/tests/testthat/helper-error-fixtures.R
+++ b/tests/testthat/helper-error-fixtures.R
@@ -16,6 +16,26 @@ test_error_fixtures$graphql_complexity_error <- list(
   )
 )
 
+test_error_fixtures$graphql_limit_error <- list(
+  "errors" = list(
+    list(
+      "message" = "Resolvers::ProjectsResolver#ids cannot accept more than 1000 items",
+      "locations" = list(
+        list(
+          "line" = 3L,
+          "column" = 11L
+        )
+      ),
+      "path" = list(
+        "projects"
+      )
+    )
+  ),
+  "data" = list(
+    "projects" = NULL
+  )
+)
+
 test_error_fixtures$graphql_error_no_groups <- list(
   "errors" = list(
     list(

--- a/tests/testthat/test-00-graphql_errors.R
+++ b/tests/testthat/test-00-graphql_errors.R
@@ -19,11 +19,22 @@ test_that("is_complexity_error works", {
   expect_false(test_graphql_github_priv$is_complexity_error(test_error_fixtures$graphql_error_no_groups))
 })
 
+test_that("is_limit_error works", {
+  expect_true(test_graphql_github_priv$is_limit_error(test_error_fixtures$graphql_limit_error))
+  expect_false(test_graphql_github_priv$is_limit_error(test_error_fixtures$graphql_error_no_groups))
+})
+
 test_that("set_graphql_error_class works", {
   error_class_object <- test_graphql_github_priv$set_graphql_error_class(
     test_error_fixtures$graphql_error_no_groups
   )
   expect_true(
     all(c("graphql_error", "graphql_no_fields_error") %in% class(error_class_object))
+  )
+  limit_error_object <- test_graphql_github_priv$set_graphql_error_class(
+    test_error_fixtures$graphql_limit_error
+  )
+  expect_true(
+    all(c("graphql_error", "graphql_limit_error") %in% class(limit_error_object))
   )
 })

--- a/tests/testthat/test-01-get_repos-GitLab.R
+++ b/tests/testthat/test-01-get_repos-GitLab.R
@@ -305,11 +305,12 @@ test_that("get_repos prints messages when falling back to batching", {
     test_fixtures$gitlab_repos_by_user_response$data$projects$edges
   )
   expect_snapshot(
-    test_graphql_gitlab$get_repos(
+    gitlab_repos <- test_graphql_gitlab$get_repos(
       repos_ids = c("test_id_1", "test_id_2"),
       verbose = TRUE
     )
   )
+  expect_repos_gitlab_gql_response(gitlab_repos, type = "repository")
 })
 
 test_that("get_repos_in_batches pulls repos in smaller chunks", {

--- a/tests/testthat/test-01-get_repos-GitLab.R
+++ b/tests/testthat/test-01-get_repos-GitLab.R
@@ -310,7 +310,12 @@ test_that("get_repos prints messages when falling back to batching", {
       verbose = TRUE
     )
   )
-  expect_repos_gitlab_gql_response(gitlab_repos, type = "repository")
+  expect_type(gitlab_repos, "list")
+  expect_gt(length(gitlab_repos), 0)
+  expect_list_contains(
+    gitlab_repos[[1]]$node,
+    c("repo_id", "repo_name", "repository", "stars", "forks", "created_at", "last_activity_at")
+  )
 })
 
 test_that("get_repos_in_batches pulls repos in smaller chunks", {

--- a/tests/testthat/test-01-get_repos-GitLab.R
+++ b/tests/testthat/test-01-get_repos-GitLab.R
@@ -264,6 +264,69 @@ test_that("get_repos breaks when response is a GraphQL 'no fields' error", {
   expect_s3_class(response, "graphql_no_fields_error")
 })
 
+test_that("get_repos falls back to batching on GraphQL complexity error", {
+  complexity_error <- test_error_fixtures$graphql_complexity_error
+  class(complexity_error) <- c(class(complexity_error), "graphql_error", "graphql_complexity_error")
+  mockery::stub(
+    test_graphql_gitlab$get_repos,
+    "private$get_repos_page",
+    complexity_error
+  )
+  mockery::stub(
+    test_graphql_gitlab$get_repos,
+    "private$get_repos_in_batches",
+    test_fixtures$gitlab_repos_by_user_response$data$projects$edges
+  )
+  repos_response <- test_graphql_gitlab$get_repos(
+    repos_ids = c("test_id_1", "test_id_2"),
+    verbose = FALSE
+  )
+  expect_type(repos_response, "list")
+  expect_gt(length(repos_response), 0)
+  expect_named(
+    repos_response[[1]]$node,
+    c("repo_id", "repo_name", "repo_path", "repo_fullpath", "repository", "stars",
+      "forks", "created_at", "last_activity_at", "languages", "issues", "namespace",
+      "repo_url")
+  )
+})
+
+test_that("get_repos prints messages when falling back to batching", {
+  complexity_error <- test_error_fixtures$graphql_complexity_error
+  class(complexity_error) <- c(class(complexity_error), "graphql_error", "graphql_complexity_error")
+  mockery::stub(
+    test_graphql_gitlab$get_repos,
+    "private$get_repos_page",
+    complexity_error
+  )
+  mockery::stub(
+    test_graphql_gitlab$get_repos,
+    "private$get_repos_in_batches",
+    test_fixtures$gitlab_repos_by_user_response$data$projects$edges
+  )
+  expect_snapshot(
+    test_graphql_gitlab$get_repos(
+      repos_ids = c("test_id_1", "test_id_2"),
+      verbose = TRUE
+    )
+  )
+})
+
+test_that("get_repos_in_batches pulls repos in smaller chunks", {
+  mockery::stub(
+    test_graphql_gitlab_priv$get_repos_in_batches,
+    "private$get_repos_page",
+    test_fixtures$gitlab_repos_by_user_response
+  )
+  repos_response <- test_graphql_gitlab_priv$get_repos_in_batches(
+    repos_ids = as.character(1:120),
+    batch_size = 50,
+    verbose = FALSE
+  )
+  expect_type(repos_response, "list")
+  expect_gt(length(repos_response), 0)
+})
+
 test_that("get_repos_from_org handles properly a GraphQL query error", {
   mockery::stub(
     test_graphql_gitlab$get_repos_from_org,

--- a/tests/testthat/test-01-get_repos-GitLab.R
+++ b/tests/testthat/test-01-get_repos-GitLab.R
@@ -264,13 +264,13 @@ test_that("get_repos breaks when response is a GraphQL 'no fields' error", {
   expect_s3_class(response, "graphql_no_fields_error")
 })
 
-test_that("get_repos falls back to batching on GraphQL complexity error", {
-  complexity_error <- test_error_fixtures$graphql_complexity_error
-  class(complexity_error) <- c(class(complexity_error), "graphql_error", "graphql_complexity_error")
+test_that("get_repos falls back to batching on GraphQL limit error", {
+  limit_error <- test_error_fixtures$graphql_limit_error
+  class(limit_error) <- c(class(limit_error), "graphql_error", "graphql_limit_error")
   mockery::stub(
     test_graphql_gitlab$get_repos,
     "private$get_repos_page",
-    complexity_error
+    limit_error
   )
   mockery::stub(
     test_graphql_gitlab$get_repos,
@@ -292,12 +292,12 @@ test_that("get_repos falls back to batching on GraphQL complexity error", {
 })
 
 test_that("get_repos prints messages when falling back to batching", {
-  complexity_error <- test_error_fixtures$graphql_complexity_error
-  class(complexity_error) <- c(class(complexity_error), "graphql_error", "graphql_complexity_error")
+  limit_error <- test_error_fixtures$graphql_limit_error
+  class(limit_error) <- c(class(limit_error), "graphql_error", "graphql_limit_error")
   mockery::stub(
     test_graphql_gitlab$get_repos,
     "private$get_repos_page",
-    complexity_error
+    limit_error
   )
   mockery::stub(
     test_graphql_gitlab$get_repos,


### PR DESCRIPTION
## Description

When a code search returns many repositories, `EngineGraphQLGitLab::get_repos()` passes all repository IDs to a single GraphQL query. This can exceed GitLab's query complexity limit, causing the request to fail.

This PR adds handling for `graphql_complexity_error` in `get_repos()`. When the error is detected, it falls back to a new `get_repos_in_batches()` private method that splits the IDs into chunks of 50 and queries each batch separately. This follows the same pattern already used in `get_files_from_org` for the same class of error.

## Related Issue(s)

Fixes #781

## How to test

1. Set up a GitLab host with an organization containing many repositories (100+).
2. Run `get_repos(gitstats, with_code = \"some_common_term\")` — previously this would fail with a GraphQL complexity error; now it should fall back to batched queries and succeed.
3. Run `testthat::test_file(\"tests/testthat/test-01-get_repos-GitLab.R\")` to verify the new unit tests pass.