### PR TITLE
Improve error handling for repos without org prefix in set_*_host()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GitStats
 Title: Standardized Git Repository Data
-Version: 2.5.0.9002
+Version: 2.5.0.9003
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
     person(given = "Kamil", family = "Koziej", email = "koziej.k@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Fixed `get_repos()` with `with_code` failing for GitLab when the code search returns more than 1000 repositories. The GraphQL resolver rejects queries with too many IDs; `get_repos()` now detects this limit error and automatically batches the IDs ([#781](https://github.com/r-world-devs/GitStats/issues/781)).
 - Improvements to parallelism visibility: added `is_parallel()` indicating whether parallel processing is currently active and public `get_*()` methods now emit `ℹ Running in parallel mode.` when `verbose = TRUE` ([#779](https://github.com/r-world-devs/GitStats/issues/779)).
-
+- Improved error handling for `set_*host()` in case user doesn't pass full path in `repos` ([#782](https://github.com/r-world-devs/GitStats/issues/782)).
 # GitStats 2.5.0
 
 This release introduces external storage backends (PostgreSQL and SQLite) for persisting pulled data across sessions, and optional parallel processing via `mirai` for faster API calls. It also brings several performance improvements, including a faster file tree retrieval and optimized GitLab repository queries.

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -507,12 +507,12 @@ GitHost <- R6::R6Class(
     },
 
     check_repositories = function(repos, verbose, .error) {
-      repos_without_org <- repos[!grepl("/", repos)]
+      repos_without_org <- repos[!grepl("/", url_decode(repos))]
       if (length(repos_without_org) > 0) {
         cli::cli_abort(
           c(
             "x" = "Repository name must be provided as a full path: {.val org/repo_name}.",
-            "i" = "Got: {.val {repos_without_org}}",
+            "i" = "Got: {.val {url_decode(repos_without_org)}}",
             "!" = "Pass the full path as seen in the web URL, e.g. {.val r-world-devs/GitStats}."
           ),
           call = NULL

--- a/R/GitHost.R
+++ b/R/GitHost.R
@@ -507,6 +507,17 @@ GitHost <- R6::R6Class(
     },
 
     check_repositories = function(repos, verbose, .error) {
+      repos_without_org <- repos[!grepl("/", repos)]
+      if (length(repos_without_org) > 0) {
+        cli::cli_abort(
+          c(
+            "x" = "Repository name must be provided as a full path: {.val org/repo_name}.",
+            "i" = "Got: {.val {repos_without_org}}",
+            "!" = "Pass the full path as seen in the web URL, e.g. {.val r-world-devs/GitStats}."
+          ),
+          call = NULL
+        )
+      }
       if (verbose) {
         cli::cli_alert(cli::col_grey("Checking repositories..."))
       }
@@ -587,7 +598,8 @@ GitHost <- R6::R6Class(
               "!" = "Please type your {tolower(type)} name as you see it in
                 web URL.",
               "i" = "E.g. do not use spaces. {type} names as you see on the
-                page may differ from their web 'address'."
+                page may differ from their web 'address'.",
+              "i" = "Repository names should be provided as full paths: {.val org/repo_name}."
             ),
             call = NULL
           )

--- a/R/set_host.R
+++ b/R/set_host.R
@@ -4,11 +4,9 @@
 #' @param host A character, optional, URL name of the host. If not passed, a
 #'   public host will be used.
 #' @param token A token.
-#' @param orgs An optional character vector of organisations. Typically used
-#'   without `repos`.
+#' @param orgs An optional character vector of organisations
 #' @param repos An optional character vector of repositories full names
-#'   (organization and repository name, e.g. "r-world-devs/GitStats"). Typically
-#'   used without `orgs`.
+#'   (organization and repository name, e.g. "r-world-devs/GitStats").
 #' @param verbose A logical, `TRUE` by default. If `FALSE` messages and printing
 #'   output is switched off.
 #' @param .error A logical to control if passing wrong input

--- a/R/set_host.R
+++ b/R/set_host.R
@@ -4,11 +4,11 @@
 #' @param host A character, optional, URL name of the host. If not passed, a
 #'   public host will be used.
 #' @param token A token.
-#' @param orgs An optional character vector of organisations. If you pass it,
-#'   `repos` parameter should stay `NULL`.
+#' @param orgs An optional character vector of organisations. Typically used
+#'   without `repos`.
 #' @param repos An optional character vector of repositories full names
-#'   (organization and repository name, e.g. "r-world-devs/GitStats"). If you
-#'   pass it, `orgs` parameter should stay `NULL`.
+#'   (organization and repository name, e.g. "r-world-devs/GitStats"). Typically
+#'   used without `orgs`.
 #' @param verbose A logical, `TRUE` by default. If `FALSE` messages and printing
 #'   output is switched off.
 #' @param .error A logical to control if passing wrong input

--- a/man/set_github_host.Rd
+++ b/man/set_github_host.Rd
@@ -22,12 +22,10 @@ public host will be used.}
 
 \item{token}{A token.}
 
-\item{orgs}{An optional character vector of organisations. If you pass it,
-\code{repos} parameter should stay \code{NULL}.}
+\item{orgs}{An optional character vector of organisations}
 
 \item{repos}{An optional character vector of repositories full names
-(organization and repository name, e.g. "r-world-devs/GitStats"). If you
-pass it, \code{orgs} parameter should stay \code{NULL}.}
+(organization and repository name, e.g. "r-world-devs/GitStats").}
 
 \item{verbose}{A logical, \code{TRUE} by default. If \code{FALSE} messages and printing
 output is switched off.}

--- a/man/set_gitlab_host.Rd
+++ b/man/set_gitlab_host.Rd
@@ -22,12 +22,10 @@ public host will be used.}
 
 \item{token}{A token.}
 
-\item{orgs}{An optional character vector of organisations. If you pass it,
-\code{repos} parameter should stay \code{NULL}.}
+\item{orgs}{An optional character vector of organisations}
 
 \item{repos}{An optional character vector of repositories full names
-(organization and repository name, e.g. "r-world-devs/GitStats"). If you
-pass it, \code{orgs} parameter should stay \code{NULL}.}
+(organization and repository name, e.g. "r-world-devs/GitStats").}
 
 \item{verbose}{A logical, \code{TRUE} by default. If \code{FALSE} messages and printing
 output is switched off.}

--- a/tests/testthat/_snaps/helpers.md
+++ b/tests/testthat/_snaps/helpers.md
@@ -37,6 +37,7 @@
     x Repository you provided does not exist or its name was passed in a wrong way: https://api.github.com/repos/r-worlddevs/GitStats
     ! Please type your repository name as you see it in web URL.
     i E.g. do not use spaces. Repository names as you see on the page may differ from their web 'address'.
+    i Repository names should be provided as full paths: "org/repo_name".
 
 # check_endpoint returns warning if they are not correct
 

--- a/tests/testthat/test-set_host.R
+++ b/tests/testthat/test-set_host.R
@@ -177,6 +177,25 @@ test_that("When wrong orgs and repos are passed they are excluded but host is cr
   }
 })
 
+test_that("Error pops out when repos are passed without org prefix", {
+  expect_error(
+    create_gitstats() |>
+      set_github_host(
+        token = Sys.getenv("GITHUB_PAT"),
+        repos = c("GitStats", "shinyCohortBuilder")
+      ),
+    "org/repo_name"
+  )
+  expect_error(
+    create_gitstats() |>
+      set_gitlab_host(
+        token = Sys.getenv("GITLAB_PAT_PUBLIC"),
+        repos = c("gitstatstesting")
+      ),
+    "org/repo_name"
+  )
+})
+
 test_that("Setting verbose for set_*_host() to FALSE works fine", {
   skip_on_cran()
   if (!integration_tests_skipped) {


### PR DESCRIPTION
- Validate repo format in check_repositories() before HTTP calls
- Add full path hint to check_endpoint() 404 error message

Closes #782