### PR TITLE
Attach set_parallel() and is_parallel() to GitStats object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # GitStats (development version)
 
+- `set_parallel()` and `is_parallel()` now take a `gitstats` object as first argument, making them pipeable (e.g. `gitstats |> set_parallel(4)`). Parallel state is stored on the object ([#790](https://github.com/r-world-devs/GitStats/issues/790)).
 - Fixed `get_repos()` with `with_code` failing for GitLab when the code search returns more than 1000 repositories. The GraphQL resolver rejects queries with too many IDs; `get_repos()` now detects this limit error and automatically batches the IDs ([#781](https://github.com/r-world-devs/GitStats/issues/781)).
 - Improvements to parallelism visibility: added `is_parallel()` indicating whether parallel processing is currently active and public `get_*()` methods now emit `ℹ Running in parallel mode.` when `verbose = TRUE` ([#779](https://github.com/r-world-devs/GitStats/issues/779)).
 - Improved error handling for `set_*_host()` in case user doesn't pass full path in `repos` ([#782](https://github.com/r-world-devs/GitStats/issues/782)).

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -616,6 +616,32 @@ GitStats <- R6::R6Class(
       private$settings$verbose
     },
 
+    set_parallel = function(workers = TRUE) {
+      if (isFALSE(workers) || identical(workers, 0L) || identical(workers, 0)) {
+        status <- mirai::daemons(0)
+        private$settings$parallel <- FALSE
+        cli::cli_alert_info("Parallel processing disabled.")
+      } else {
+        if (isTRUE(workers)) {
+          workers <- parallel::detectCores(logical = FALSE)
+          if (is.na(workers) || workers < 2L) workers <- 2L
+        }
+        status <- mirai::daemons(workers)
+        ns <- asNamespace("GitStats")
+        ns_objects <- as.list(ns, all.names = TRUE)
+        do.call(mirai::everywhere, c(list(quote({})), ns_objects))
+        private$settings$parallel <- TRUE
+        cli::cli_alert_success(
+          "Parallel processing enabled with {workers} workers."
+        )
+      }
+      return(invisible(status))
+    },
+
+    is_parallel = function() {
+      private$settings$parallel && mirai_active()
+    },
+
     set_local_storage = function() {
       private$storage_backend <- StorageLocal$new()
       private$propagate_storage_to_hosts()
@@ -728,8 +754,9 @@ GitStats <- R6::R6Class(
     hosts = list(),
 
     settings = list(
-      verbose = TRUE,
-      cache   = TRUE
+      verbose  = TRUE,
+      cache    = TRUE,
+      parallel = FALSE
     ),
 
     storage_backend = NULL,
@@ -752,7 +779,7 @@ GitStats <- R6::R6Class(
     },
 
     inform_parallel = function(verbose) {
-      if (verbose && mirai_active()) {
+      if (verbose && self$is_parallel()) {
         cli::cli_alert_info("Running in parallel mode.")
       }
     },
@@ -1460,54 +1487,41 @@ GitStats <- R6::R6Class(
 #'   When enabled, GitStats fetches data from multiple repositories
 #'   concurrently. Call `set_parallel(FALSE)` or `set_parallel(0)` to revert
 #'   to sequential execution.
+#' @param gitstats A GitStats object.
 #' @param workers Number of parallel workers. Set to `TRUE` for automatic
 #'   detection, a positive integer for a specific count, or `FALSE`/`0` to
 #'   disable parallelism.
-#' @return Invisibly returns the status from `mirai::daemons()`.
+#' @return A `GitStats` object.
 #' @examples
 #' \dontrun{
 #'   my_gitstats <- create_gitstats() |>
 #'     set_github_host(
 #'       token = Sys.getenv("GITHUB_PAT"),
 #'       orgs = c("r-world-devs", "openpharma")
-#'     )
-#'   set_parallel(4)
+#'     ) |>
+#'     set_parallel(4)
 #'   get_commits(my_gitstats, since = "2024-01-01")
-#'   set_parallel(FALSE) # revert to sequential
+#'   my_gitstats |> set_parallel(FALSE) # revert to sequential
 #' }
 #' @export
-set_parallel <- function(workers = TRUE) {
-  if (isFALSE(workers) || identical(workers, 0L) || identical(workers, 0)) {
-    status <- mirai::daemons(0)
-    cli::cli_alert_info("Parallel processing disabled.")
-  } else {
-    if (isTRUE(workers)) {
-      workers <- parallel::detectCores(logical = FALSE)
-      if (is.na(workers) || workers < 2L) workers <- 2L
-    }
-    status <- mirai::daemons(workers)
-    # Export all GitStats namespace objects to daemon global environments.
-    # This works regardless of whether the package is installed or loaded
-    # via devtools::load_all(). Using ... (not .args) so objects are
-    # assigned to the daemon's global env where they can be found by name.
-    ns <- asNamespace("GitStats")
-    ns_objects <- as.list(ns, all.names = TRUE)
-    do.call(mirai::everywhere, c(list(quote({})), ns_objects))
-    cli::cli_alert_success(
-      "Parallel processing enabled with {workers} workers."
-    )
-  }
-  return(invisible(status))
+set_parallel <- function(gitstats, workers = TRUE) {
+  gitstats$set_parallel(workers = workers)
+  return(invisible(gitstats))
 }
 
 #' @title Check if parallel processing is active
 #' @name is_parallel
-#' @description Returns `TRUE` when mirai daemons are running (i.e.
-#'   `set_parallel()` has been called), `FALSE` otherwise.
+#' @description Returns `TRUE` when mirai daemons are running on the given
+#'   `GitStats` object (i.e. `set_parallel()` has been called), `FALSE`
+#'   otherwise.
+#' @param gitstats A GitStats object.
 #' @return A logical scalar.
 #' @examples
-#' is_parallel()
+#' \dontrun{
+#'   my_gitstats <- create_gitstats()
+#'   is_parallel(my_gitstats)
+#' }
 #' @export
-is_parallel <- function() {
-  mirai_active()
+is_parallel <- function(gitstats) {
+  gitstats$is_parallel()
 }

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -1505,6 +1505,13 @@ GitStats <- R6::R6Class(
 #' }
 #' @export
 set_parallel <- function(gitstats, workers = TRUE) {
+  if (missing(gitstats) || !inherits(gitstats, "GitStats")) {
+    cli::cli_abort(c(
+      "{.fun set_parallel} requires a {.cls GitStats} object as its first argument.",
+      "i" = "Use {.code my_gitstats |> set_parallel(workers)} or
+             {.code set_parallel(my_gitstats, workers)}."
+    ), call = NULL)
+  }
   gitstats$set_parallel(workers = workers)
   return(invisible(gitstats))
 }
@@ -1523,5 +1530,11 @@ set_parallel <- function(gitstats, workers = TRUE) {
 #' }
 #' @export
 is_parallel <- function(gitstats) {
+  if (missing(gitstats) || !inherits(gitstats, "GitStats")) {
+    cli::cli_abort(c(
+      "{.fun is_parallel} requires a {.cls GitStats} object as its first argument.",
+      "i" = "Use {.code is_parallel(my_gitstats)}."
+    ), call = NULL)
+  }
   gitstats$is_parallel()
 }

--- a/R/GitStats.R
+++ b/R/GitStats.R
@@ -616,7 +616,7 @@ GitStats <- R6::R6Class(
       private$settings$verbose
     },
 
-    set_parallel = function(workers = TRUE) {
+    set_parallel = function(workers = 10L) {
       if (isFALSE(workers) || identical(workers, 0L) || identical(workers, 0)) {
         status <- mirai::daemons(0)
         private$settings$parallel <- FALSE
@@ -1504,7 +1504,7 @@ GitStats <- R6::R6Class(
 #'   my_gitstats |> set_parallel(FALSE) # revert to sequential
 #' }
 #' @export
-set_parallel <- function(gitstats, workers = TRUE) {
+set_parallel <- function(gitstats, workers = 10L) {
   if (missing(gitstats) || !inherits(gitstats, "GitStats")) {
     cli::cli_abort(c(
       "{.fun set_parallel} requires a {.cls GitStats} object as its first argument.",

--- a/README.Rmd
+++ b/README.Rmd
@@ -73,7 +73,8 @@ git_stats <- create_gitstats() |>
 Optionally, you can run `GitStats` functions in parallel (with `mirai` package underneath):
 
 ```{r}
-git_stats <- git_stats |> set_parallel()
+git_stats |>
+  set_parallel()
 ```
 
 Get commits:

--- a/README.Rmd
+++ b/README.Rmd
@@ -73,7 +73,7 @@ git_stats <- create_gitstats() |>
 Optionally, you can run `GitStats` functions in parallel (with `mirai` package underneath):
 
 ```{r}
-set_parallel()
+git_stats <- git_stats |> set_parallel()
 ```
 
 Get commits:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Optionally, you can run `GitStats` functions in parallel (with `mirai`
 package underneath):
 
 ``` r
-set_parallel()
+git_stats |>
+  set_parallel()
 ```
 
 Get commits:
@@ -78,7 +79,7 @@ commits <- git_stats |>
   )
 
 commits
-#> # A tibble: 3,510 × 11
+#> # A tibble: 3,713 × 11
 #>    repo_name id    committed_date      author author_login author_name additions
 #>    <chr>     <chr> <dttm>              <chr>  <chr>        <chr>           <int>
 #>  1 gitstats… 7f48… 2024-09-10 11:12:59 Macie… <NA>         Maciej Ban…         0
@@ -88,10 +89,10 @@ commits
 #>  5 gitstats… 7e87… 2023-02-10 09:48:55 Macie… <NA>         Maciej Ban…         1
 #>  6 gitstats… 62c4… 2023-02-10 09:17:24 Macie… <NA>         Maciej Ban…         2
 #>  7 gitstats… 55cf… 2023-02-10 09:07:54 Macie… <NA>         Maciej Ban…        92
-#>  8 shinyGiz… C_kw… 2023-05-08 09:43:31 Kryst… krystian8207 Krystian I…        18
-#>  9 shinyGiz… C_kw… 2023-04-28 12:30:40 Kamil… <NA>         Kamil Kozi…        18
-#> 10 shinyGiz… C_kw… 2023-03-01 15:05:10 Kryst… krystian8207 Krystian I…       296
-#> # ℹ 3,500 more rows
+#>  8 shinyGiz… C_kw… 2026-04-03 22:27:09 Kryst… krystian8207 Krystian I…      1638
+#>  9 shinyGiz… C_kw… 2026-04-03 21:23:33 Kryst… krystian8207 Krystian I…        42
+#> 10 shinyGiz… C_kw… 2026-04-03 20:29:59 Kryst… krystian8207 Krystian I…        18
+#> # ℹ 3,703 more rows
 #> # ℹ 4 more variables: deletions <int>, organization <chr>, repo_url <chr>,
 #> #   api_url <glue>
 
@@ -100,7 +101,7 @@ commits |>
     time_aggregation = "month",
     group_var = author
   )
-#> # A tibble: 378 × 4
+#> # A tibble: 382 × 4
 #>    stats_date          githost author             stats
 #>    <dttm>              <chr>   <chr>              <int>
 #>  1 2022-01-01 00:00:00 github  Admin_mschuemi         1
@@ -113,7 +114,7 @@ commits |>
 #>  8 2022-02-01 00:00:00 github  Reijo Sund             1
 #>  9 2022-02-01 00:00:00 github  eitsupi                1
 #> 10 2022-03-01 00:00:00 github  Maximilian Girlich    14
-#> # ℹ 368 more rows
+#> # ℹ 372 more rows
 ```
 
 Get repositories with specific code:
@@ -149,12 +150,12 @@ git_stats |>
     pattern = "\\.md",
     depth = 2L
   )
-#> # A tibble: 68 × 10
+#> # A tibble: 63 × 10
 #>    repo_id      repo_name  organization file_path file_content file_size file_id
 #>    <chr>        <chr>      <chr>        <chr>     <chr>            <int> <chr>  
 #>  1 43398933     gitstatst… mbtests      README.md "# GitStats…       122 fe2407…
-#>  2 R_kgDOHNMr2w shinyGizmo r-world-devs NEWS.md   "# shinyGiz…      2186 c13994…
-#>  3 R_kgDOHNMr2w shinyGizmo r-world-devs README.md "\n# shinyG…      2337 585f62…
+#>  2 R_kgDOHNMr2w shinyGizmo r-world-devs NEWS.md   "# shinyGiz…      2382 466c53…
+#>  3 R_kgDOHNMr2w shinyGizmo r-world-devs README.md "\n# shinyG…      4271 388469…
 #>  4 R_kgDOHNMr2w shinyGizmo r-world-devs cran-com… "## Test en…      1700 cfcaf4…
 #>  5 R_kgDOHYNOFQ cohortBui… r-world-devs NEWS.md   "# cohortBu…      1369 8c5cf3…
 #>  6 R_kgDOHYNOFQ cohortBui… r-world-devs README.md "\n# cohort…     13382 ebc919…
@@ -162,7 +163,7 @@ git_stats |>
 #>  8 R_kgDOHYNrJw shinyCoho… r-world-devs README.md "\n# shinyC…      3355 e49dfe…
 #>  9 R_kgDOHYNxtw cohortBui… r-world-devs README.md "\n# cohort…      3472 d4687c…
 #> 10 R_kgDOIvtxsg GitStats   r-world-devs LICENSE.… "# MIT Lice…      1075 141471…
-#> # ℹ 58 more rows
+#> # ℹ 53 more rows
 #> # ℹ 3 more variables: repo_url <chr>, commit_sha <chr>, api_url <chr>
 ```
 
@@ -173,7 +174,7 @@ git_stats |>
   get_pull_requests(
     since = "2022-01-01"
   )
-#> # A tibble: 420 × 10
+#> # A tibble: 444 × 10
 #>    repo_name       number created_at          merged_at           state  author 
 #>    <chr>           <chr>  <dttm>              <dttm>              <chr>  <chr>  
 #>  1 gitstatstesting 2      2026-02-25 09:34:18 NA                  closed <NA>   
@@ -186,7 +187,7 @@ git_stats |>
 #>  8 shinyGizmo      16     2022-06-15 13:48:08 2022-06-15 14:12:52 merged krysti…
 #>  9 shinyGizmo      17     2022-06-17 10:55:10 2022-06-17 10:56:09 merged krysti…
 #> 10 shinyGizmo      19     2022-07-05 10:01:44 2022-07-05 11:05:30 merged krysti…
-#> # ℹ 410 more rows
+#> # ℹ 434 more rows
 #> # ℹ 4 more variables: source_branch <chr>, target_branch <chr>,
 #> #   organization <chr>, api_url <glue>
 ```
@@ -200,11 +201,11 @@ git_stats
 #> Scanning scope: 
 #>  Organizations: [1] r-world-devs
 #>  Repositories: [2] mbtests/gitstatstesting, openpharma/DataFakeR
-#> Storage: 
+#> Storage [local]:
+#>  Commits: 3713 [date range: 2022-01-01 - 2026-04-21]
 #>  Repositories: 9 
-#>  Commits: 3510 [date range: 2022-01-01 - 2026-03-18]
-#>  Files: 68 [file pattern: \.md]
-#>  Pull_requests: 420 [date range: 2022-01-01 - 2026-03-18]
+#>  Files: 63 [file pattern: \.md]
+#>  Pull_requests: 444 [date range: 2022-01-01 - 2026-04-21]
 ```
 
 ## See also

--- a/examples/parallel_workflow.R
+++ b/examples/parallel_workflow.R
@@ -1,15 +1,14 @@
 devtools::load_all()
 
-set_parallel(4)
-
 my_gitstats <- create_gitstats() |>
   set_github_host(
     token = Sys.getenv("GITHUB_PAT"),
     orgs = c("r-world-devs", "openpharma")
-  )
+  ) |>
+  set_parallel(4)
 
 get_commits(my_gitstats, since = "2024-01-01", cache = FALSE)
 
-set_parallel(FALSE)
+my_gitstats |> set_parallel(FALSE)
 
 get_commits(my_gitstats, since = "2024-01-01", cache = FALSE)

--- a/man/is_parallel.Rd
+++ b/man/is_parallel.Rd
@@ -4,15 +4,22 @@
 \alias{is_parallel}
 \title{Check if parallel processing is active}
 \usage{
-is_parallel()
+is_parallel(gitstats)
+}
+\arguments{
+\item{gitstats}{A GitStats object.}
 }
 \value{
 A logical scalar.
 }
 \description{
-Returns \code{TRUE} when mirai daemons are running (i.e.
-\code{set_parallel()} has been called), \code{FALSE} otherwise.
+Returns \code{TRUE} when mirai daemons are running on the given
+\code{GitStats} object (i.e. \code{set_parallel()} has been called), \code{FALSE}
+otherwise.
 }
 \examples{
-is_parallel()
+\dontrun{
+  my_gitstats <- create_gitstats()
+  is_parallel(my_gitstats)
+}
 }

--- a/man/set_parallel.Rd
+++ b/man/set_parallel.Rd
@@ -4,7 +4,7 @@
 \alias{set_parallel}
 \title{Enable parallel processing}
 \usage{
-set_parallel(gitstats, workers = TRUE)
+set_parallel(gitstats, workers = 10L)
 }
 \arguments{
 \item{gitstats}{A GitStats object.}

--- a/man/set_parallel.Rd
+++ b/man/set_parallel.Rd
@@ -4,15 +4,17 @@
 \alias{set_parallel}
 \title{Enable parallel processing}
 \usage{
-set_parallel(workers = TRUE)
+set_parallel(gitstats, workers = TRUE)
 }
 \arguments{
+\item{gitstats}{A GitStats object.}
+
 \item{workers}{Number of parallel workers. Set to \code{TRUE} for automatic
 detection, a positive integer for a specific count, or \code{FALSE}/\code{0} to
 disable parallelism.}
 }
 \value{
-Invisibly returns the status from \code{mirai::daemons()}.
+A \code{GitStats} object.
 }
 \description{
 Set up parallel processing for API calls using mirai daemons.
@@ -26,9 +28,9 @@ to sequential execution.
     set_github_host(
       token = Sys.getenv("GITHUB_PAT"),
       orgs = c("r-world-devs", "openpharma")
-    )
-  set_parallel(4)
+    ) |>
+    set_parallel(4)
   get_commits(my_gitstats, since = "2024-01-01")
-  set_parallel(FALSE) # revert to sequential
+  my_gitstats |> set_parallel(FALSE) # revert to sequential
 }
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,4 +1,4 @@
-set_parallel(FALSE)
+mirai::daemons(0)
 
 integration_tests_skipped <- Sys.getenv("GITSTATS_INTEGRATION_TEST_SKIPPED", unset = "true") |>
   as.logical()

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -71,6 +71,22 @@ test_that("`gitstats_map_chr` handles empty input in sequential mode", {
   expect_equal(result, character(0))
 })
 
+# ---- set_parallel / is_parallel input validation ----
+
+test_that("`set_parallel` errors when called without a GitStats object", {
+  expect_error(set_parallel(4), "GitStats")
+  expect_error(set_parallel(TRUE), "GitStats")
+  expect_error(set_parallel(FALSE), "GitStats")
+  expect_error(set_parallel("not_gitstats", 4), "GitStats")
+  expect_error(set_parallel(list(), 2), "GitStats")
+})
+
+test_that("`is_parallel` errors when called without a GitStats object", {
+  expect_error(is_parallel(), "GitStats")
+  expect_error(is_parallel("not_gitstats"), "GitStats")
+  expect_error(is_parallel(42), "GitStats")
+})
+
 # ---- set_parallel ----
 
 test_that("`set_parallel` enables and disables daemons", {

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -76,108 +76,145 @@ test_that("`gitstats_map_chr` handles empty input in sequential mode", {
 test_that("`set_parallel` enables and disables daemons", {
   skip_if(Sys.getenv("R_COVR") == "true", "mirai daemons conflict with covr tracing")
   withr::defer(mirai::daemons(0))
+  gs <- create_gitstats()
 
-  expect_message(set_parallel(2), "Parallel processing enabled with 2 workers")
-  expect_true(mirai_active())
+  expect_message(set_parallel(gs, 2), "Parallel processing enabled with 2 workers")
+  expect_true(is_parallel(gs))
 
-  expect_message(set_parallel(FALSE), "Parallel processing disabled")
-  expect_false(mirai_active())
+  expect_message(set_parallel(gs, FALSE), "Parallel processing disabled")
+  expect_false(is_parallel(gs))
 
-  expect_message(set_parallel(0), "Parallel processing disabled")
-  expect_false(mirai_active())
+  expect_message(set_parallel(gs, 0), "Parallel processing disabled")
+  expect_false(is_parallel(gs))
 
-  expect_message(set_parallel(0L), "Parallel processing disabled")
-  expect_false(mirai_active())
+  expect_message(set_parallel(gs, 0L), "Parallel processing disabled")
+  expect_false(is_parallel(gs))
 })
 
 test_that("`set_parallel(TRUE)` auto-detects workers", {
   skip_if(Sys.getenv("R_COVR") == "true", "mirai daemons conflict with covr tracing")
   withr::defer(mirai::daemons(0))
-  expect_message(set_parallel(TRUE), "Parallel processing enabled with \\d+ workers")
-  expect_true(mirai_active())
+  gs <- create_gitstats()
+  expect_message(set_parallel(gs, TRUE), "Parallel processing enabled with \\d+ workers")
+  expect_true(is_parallel(gs))
 })
 
 # ---- set_parallel (mocked, runs under covr) ----
 
 test_that("`set_parallel` disable path executes under covr", {
+  gs <- create_gitstats()
   mock_daemons <- mockery::mock("status_off")
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
 
-  result <- set_parallel(FALSE)
-  expect_equal(result, "status_off")
+  gs$set_parallel(FALSE)
   mockery::expect_called(mock_daemons, 1)
   expect_equal(mockery::mock_args(mock_daemons)[[1]], list(0))
+  expect_false(gs$is_parallel())
 })
 
 test_that("`set_parallel(0)` disable path executes under covr", {
+  gs <- create_gitstats()
   mock_daemons <- mockery::mock("status_off")
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
 
-  result <- set_parallel(0)
-  expect_equal(result, "status_off")
+  gs$set_parallel(0)
   mockery::expect_called(mock_daemons, 1)
+  expect_false(gs$is_parallel())
 })
 
 test_that("`set_parallel(0L)` disable path executes under covr", {
+  gs <- create_gitstats()
   mock_daemons <- mockery::mock("status_off")
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
 
-  result <- set_parallel(0L)
-  expect_equal(result, "status_off")
+  gs$set_parallel(0L)
   mockery::expect_called(mock_daemons, 1)
+  expect_false(gs$is_parallel())
 })
 
 test_that("`set_parallel` enable path with explicit workers executes under covr", {
+  gs <- create_gitstats()
   mock_daemons <- mockery::mock("status_on")
-  mock_everywhere <- mockery::mock(NULL)
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
-  mockery::stub(set_parallel, "do.call", NULL)
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
+  mockery::stub(gs$set_parallel, "do.call", NULL)
 
-  result <- set_parallel(4)
-  expect_equal(result, "status_on")
+  gs$set_parallel(4)
   mockery::expect_called(mock_daemons, 1)
   expect_equal(mockery::mock_args(mock_daemons)[[1]], list(4))
 })
 
 test_that("`set_parallel(TRUE)` auto-detects and falls back to 2 when cores < 2", {
+  gs <- create_gitstats()
   mock_daemons <- mockery::mock("status_on")
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
-  mockery::stub(set_parallel, "parallel::detectCores", 1L)
-  mockery::stub(set_parallel, "do.call", NULL)
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
+  mockery::stub(gs$set_parallel, "parallel::detectCores", 1L)
+  mockery::stub(gs$set_parallel, "do.call", NULL)
 
-  result <- set_parallel(TRUE)
-  expect_equal(result, "status_on")
+  gs$set_parallel(TRUE)
   # Should have been called with 2 (the fallback)
   expect_equal(mockery::mock_args(mock_daemons)[[1]], list(2))
 })
 
 test_that("`set_parallel(TRUE)` falls back to 2 when detectCores returns NA", {
+  gs <- create_gitstats()
   mock_daemons <- mockery::mock("status_on")
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
-  mockery::stub(set_parallel, "parallel::detectCores", NA_integer_)
-  mockery::stub(set_parallel, "do.call", NULL)
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
+  mockery::stub(gs$set_parallel, "parallel::detectCores", NA_integer_)
+  mockery::stub(gs$set_parallel, "do.call", NULL)
 
-  result <- set_parallel(TRUE)
-  expect_equal(result, "status_on")
+  gs$set_parallel(TRUE)
   expect_equal(mockery::mock_args(mock_daemons)[[1]], list(2))
 })
 
 test_that("`set_parallel(TRUE)` uses detected cores when >= 2", {
+  gs <- create_gitstats()
   mock_daemons <- mockery::mock("status_on")
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
-  mockery::stub(set_parallel, "parallel::detectCores", 8L)
-  mockery::stub(set_parallel, "do.call", NULL)
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
+  mockery::stub(gs$set_parallel, "parallel::detectCores", 8L)
+  mockery::stub(gs$set_parallel, "do.call", NULL)
 
-  result <- set_parallel(TRUE)
-  expect_equal(result, "status_on")
+  gs$set_parallel(TRUE)
   expect_equal(mockery::mock_args(mock_daemons)[[1]], list(8))
 })
 
-test_that("`set_parallel` returns invisibly", {
-  mock_daemons <- mockery::mock("status")
-  mockery::stub(set_parallel, "mirai::daemons", mock_daemons)
+test_that("`set_parallel` returns GitStats object invisibly", {
+  gs <- create_gitstats()
+  mock_daemons <- mockery::mock("status", "status")
+  mockery::stub(gs$set_parallel, "mirai::daemons", mock_daemons)
 
-  expect_invisible(set_parallel(FALSE))
+  result <- set_parallel(gs, FALSE)
+  expect_invisible(set_parallel(gs, FALSE))
+  expect_s3_class(result, "GitStats")
+})
+
+test_that("`set_parallel` can be used in a pipeline", {
+  skip_if(Sys.getenv("R_COVR") == "true", "mirai daemons conflict with covr tracing")
+  withr::defer(mirai::daemons(0))
+
+  gs <- create_gitstats() |>
+    set_parallel(2)
+  expect_true(is_parallel(gs))
+  expect_s3_class(gs, "GitStats")
+})
+
+# ---- is_parallel ----
+
+test_that("`is_parallel` returns FALSE for a fresh GitStats object", {
+  gs <- create_gitstats()
+  expect_false(is_parallel(gs))
+})
+
+test_that("`is_parallel` reflects parallel state per object", {
+  skip_if(Sys.getenv("R_COVR") == "true", "mirai daemons conflict with covr tracing")
+  withr::defer(mirai::daemons(0))
+
+  gs1 <- create_gitstats()
+  gs2 <- create_gitstats()
+
+  set_parallel(gs1, 2)
+  # gs1 was set to parallel, gs2 was not
+  expect_true(is_parallel(gs1))
+  expect_false(is_parallel(gs2))
 })
 
 # ---- parallel execution paths (single daemon startup) ----
@@ -185,7 +222,8 @@ test_that("`set_parallel` returns invisibly", {
 test_that("gitstats_map/map_chr work via mirai_map when daemons are active", {
   skip_if(Sys.getenv("R_COVR") == "true", "mirai daemons conflict with covr tracing")
   withr::defer(mirai::daemons(0))
-  set_parallel(2)
+  gs <- create_gitstats()
+  set_parallel(gs, 2)
 
   # gitstats_map without progress
   result <- gitstats_map(1:3, function(x) x * 2)
@@ -203,4 +241,3 @@ test_that("gitstats_map/map_chr work via mirai_map when daemons are active", {
   result <- gitstats_map_chr(c("x", "y"), function(x) toupper(x), .progress = TRUE)
   expect_equal(result, c("X", "Y"))
 })
-

--- a/vignettes/store_data.Rmd
+++ b/vignettes/store_data.Rmd
@@ -34,7 +34,13 @@ git_stats <- create_gitstats() |>
     orgs = c("mbtests"),
     token = Sys.getenv("GITLAB_PAT_PUBLIC")
   )
-git_stats <- git_stats |> set_parallel(10) # optionally speed up processing
+```
+
+Optionally speed up processing.
+
+```{r}
+git_stats |> 
+  set_parallel(10)
 ```
 
 As scanning scope was set to `organizations` (`orgs` parameter in `set_*_host()`), `GitStats` will pull all repositories from these organizations.

--- a/vignettes/store_data.Rmd
+++ b/vignettes/store_data.Rmd
@@ -39,8 +39,8 @@ git_stats <- create_gitstats() |>
 Optionally speed up processing.
 
 ```{r}
-git_stats |> 
-  set_parallel(10)
+git_stats |>
+  set_parallel(10L)
 ```
 
 As scanning scope was set to `organizations` (`orgs` parameter in `set_*_host()`), `GitStats` will pull all repositories from these organizations.

--- a/vignettes/store_data.Rmd
+++ b/vignettes/store_data.Rmd
@@ -34,7 +34,7 @@ git_stats <- create_gitstats() |>
     orgs = c("mbtests"),
     token = Sys.getenv("GITLAB_PAT_PUBLIC")
   )
-set_parallel(10) # optionally speed up processing
+git_stats <- git_stats |> set_parallel(10) # optionally speed up processing
 ```
 
 As scanning scope was set to `organizations` (`orgs` parameter in `set_*_host()`), `GitStats` will pull all repositories from these organizations.


### PR DESCRIPTION
Closes #790 (sub-issue of #777)

## Motivation

`set_parallel()` and `is_parallel()` operated on global mirai daemon state, making them inconsistent with other GitStats setters that pipe from the object. Parallel configuration didn't travel with the `GitStats` object.

## Changes

- **R6 methods**: Added `set_parallel()` and `is_parallel()` as public methods on the `GitStats` class. Parallel state is stored in `private$settings$parallel`.
- **Wrapper functions**: `set_parallel(gitstats, workers)` and `is_parallel(gitstats)` now take a `gitstats` object as first argument and return `invisible(gitstats)`, enabling pipeline usage:
  ```r
  my_gitstats <- create_gitstats() |>
    set_github_host(...) |>
    set_parallel(4)
  ```
- **`inform_parallel()`**: Now checks `self$is_parallel()` (object-level state) instead of global `mirai_active()`.
- **Tests**: Updated all `set_parallel`/`is_parallel` tests to use the new signature. Added tests for pipeline usage and per-object parallel state.
- **Docs**: Updated `README.Rmd`, `vignettes/store_data.Rmd`, `examples/parallel_workflow.R`, and `NEWS.md`.

## Breaking change

`set_parallel()` and `is_parallel()` now require a `gitstats` object as first argument. The `man/*.Rd` files need regeneration via `devtools::document()` (R was not available in the dev environment)."