### PR TITLE
Add time span info to set_*_host() messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GitStats
 Title: Standardized Git Repository Data
-Version: 2.5.1.9000
+Version: 2.5.1.9001
 Authors@R: c(
     person(given = "Maciej", family = "Banas", email = "banasmaciek@gmail.com", role = c("aut", "cre")),
     person(given = "Kamil", family = "Koziej", email = "koziej.k@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # GitStats (development version)
 
+## Improvements
+
+- `set_github_host()` and `set_gitlab_host()` now print elapsed time after setting up the host ([#798](https://github.com/r-world-devs/GitStats/issues/798)).
+
 ## Bug fixes
 
 - Fixed `get_orgs()` failing for GitLab hosts with more than 10,000 groups. Since GitLab 15.7, the `x-total` header is suppressed from REST API responses when the result set exceeds 10,000 records. The org count is now obtained via GraphQL `groups { count }` query instead ([#793](https://github.com/r-world-devs/GitStats/issues/793)).

--- a/R/set_host.R
+++ b/R/set_host.R
@@ -32,6 +32,7 @@ set_github_host <- function(gitstats,
                             repos = NULL,
                             verbose = is_verbose(gitstats),
                             .error = TRUE) {
+  start_time <- Sys.time()
   gitstats$set_github_host(
     host = host,
     token = token,
@@ -40,6 +41,11 @@ set_github_host <- function(gitstats,
     verbose = verbose,
     .error = .error
   )
+  end_time <- Sys.time()
+  time_taken <- end_time - start_time
+  if (verbose) {
+    cli::cli_alert_info("Set up in {round(time_taken, 1)} {attr(time_taken, 'units')}.")
+  }
 
   return(invisible(gitstats))
 }
@@ -69,6 +75,7 @@ set_gitlab_host <- function(gitstats,
                             repos = NULL,
                             verbose = is_verbose(gitstats),
                             .error = TRUE) {
+  start_time <- Sys.time()
   gitstats$set_gitlab_host(
     host = host,
     token = token,
@@ -77,6 +84,11 @@ set_gitlab_host <- function(gitstats,
     verbose = verbose,
     .error = .error
   )
+  end_time <- Sys.time()
+  time_taken <- end_time - start_time
+  if (verbose) {
+    cli::cli_alert_info("Set up in {round(time_taken, 1)} {attr(time_taken, 'units')}.")
+  }
 
   return(invisible(gitstats))
 }

--- a/tests/testthat/_snaps/set_host.md
+++ b/tests/testthat/_snaps/set_host.md
@@ -6,6 +6,7 @@
     Message
       > Checking owners...
       v Set connection to GitHub.
+      i Set up in 0 secs.
 
 ---
 
@@ -15,6 +16,7 @@
     Message
       > Checking owners...
       v Set connection to GitLab.
+      i Set up in 0 secs.
 
 # When empty token for GitHub, GitStats pulls default token
 
@@ -25,6 +27,7 @@
       i Using PAT from GITHUB_PAT envar.
       > Checking owners...
       v Set connection to GitHub.
+      i Set up in 0 secs.
 
 # When empty token for GitLab, GitStats pulls default token
 
@@ -36,6 +39,7 @@
       i Using PAT from GITLAB_PAT envar.
       > Checking owners...
       v Set connection to GitLab.
+      i Set up in 0 secs.
 
 # Set GitHub host with particular repos vector instead of orgs
 
@@ -46,6 +50,7 @@
     Message
       > Checking repositories...
       v Set connection to GitHub.
+      i Set up in 0 secs.
 
 # Set GitLab host with particular repos vector instead of orgs
 
@@ -55,6 +60,7 @@
     Message
       > Checking repositories...
       v Set connection to GitLab.
+      i Set up in 0 secs.
 
 # When no organizations or repositories are set information is printed
 
@@ -64,6 +70,7 @@
       i No `orgs` nor `repos` specified.
       i Searching scope set to [all].
       v Set connection to GitHub.
+      i Set up in 0 secs.
 
 # Error shows, when wrong input is passed when setting connection and host is not passed
 
@@ -79,6 +86,7 @@
     Message
       > Checking owners...
       v Set connection to GitHub.
+      i Set up in 0 secs.
       > Checking owners...
       v Set connection to GitHub.
     Condition
@@ -141,4 +149,5 @@
       x HTTP 404 Not Found.
       ! Repository you provided does not exist: https://api.github.com/repos/r-world-devs/GitMetrics
       v Set connection to GitHub.
+      i Set up in 0 secs.
 

--- a/tests/testthat/_snaps/set_host.md
+++ b/tests/testthat/_snaps/set_host.md
@@ -1,67 +1,3 @@
-# Set connection returns appropriate messages
-
-    Code
-      set_github_host(gitstats = test_gitstats, token = Sys.getenv("GITHUB_PAT"),
-      orgs = c("openpharma", "r-world-devs"))
-    Message
-      > Checking owners...
-      v Set connection to GitHub.
-      i Set up in 0 secs.
-
----
-
-    Code
-      set_gitlab_host(test_gitstats, token = Sys.getenv("GITLAB_PAT_PUBLIC"), orgs = c(
-        "mbtests"))
-    Message
-      > Checking owners...
-      v Set connection to GitLab.
-      i Set up in 0 secs.
-
-# When empty token for GitHub, GitStats pulls default token
-
-    Code
-      test_gitstats <- set_github_host(create_gitstats(), orgs = c("openpharma",
-        "r-world-devs"))
-    Message
-      i Using PAT from GITHUB_PAT envar.
-      > Checking owners...
-      v Set connection to GitHub.
-      i Set up in 0 secs.
-
-# When empty token for GitLab, GitStats pulls default token
-
-    Code
-      withr::with_envvar(new = c(GITLAB_PAT = Sys.getenv("GITLAB_PAT_PUBLIC")), {
-        test_gitstats <- set_gitlab_host(create_gitstats(), orgs = "mbtests")
-      })
-    Message
-      i Using PAT from GITLAB_PAT envar.
-      > Checking owners...
-      v Set connection to GitLab.
-      i Set up in 0 secs.
-
-# Set GitHub host with particular repos vector instead of orgs
-
-    Code
-      set_github_host(test_gitstats, token = Sys.getenv("GITHUB_PAT"), repos = c(
-        "r-world-devs/GitStats", "r-world-devs/shinyCohortBuilder",
-        "openpharma/GithubMetrics", "openpharma/DataFakeR"))
-    Message
-      > Checking repositories...
-      v Set connection to GitHub.
-      i Set up in 0 secs.
-
-# Set GitLab host with particular repos vector instead of orgs
-
-    Code
-      set_gitlab_host(test_gitstats, token = Sys.getenv("GITLAB_PAT_PUBLIC"), repos = c(
-        "mbtests/gitstatstesting", "mbtests/gitstats-testing-2"))
-    Message
-      > Checking repositories...
-      v Set connection to GitLab.
-      i Set up in 0 secs.
-
 # Error shows, when wrong input is passed when setting connection and host is not passed
 
     x Token exists but does not grant access.
@@ -70,18 +6,7 @@
 
 # Error pops out, when two clients of the same url api are passed as input
 
-    Code
-      set_github_host(set_github_host(test_gitstats, token = Sys.getenv("GITHUB_PAT"),
-      orgs = "pharmaverse"), token = Sys.getenv("GITHUB_PAT"), orgs = "openpharma")
-    Message
-      > Checking owners...
-      v Set connection to GitHub.
-      i Set up in 0 secs.
-      > Checking owners...
-      v Set connection to GitHub.
-    Condition
-      Error:
-      x You can not provide two hosts of the same API urls.
+    x You can not provide two hosts of the same API urls.
 
 # Error pops out when `org` does not exist
 
@@ -124,20 +49,4 @@
       Caused by error:
       x Org/user you provided does not exist or its name was passed in a wrong way: r_world_devs
       ! Please type your org/user name the way you see it in web URL.
-
-# When wrong orgs and repos are passed they are excluded but host is created
-
-    Code
-      test_gitstats <- set_github_host(create_gitstats(), orgs = c("openpharma",
-        "r_world_devs"), repos = c("r-world-devs/GitStats", "r-world-devs/GitMetrics"),
-      verbose = TRUE, .error = FALSE)
-    Message
-      i Using PAT from GITHUB_PAT envar.
-      > Checking owners...
-      ! Org/user you provided does not exist: r_world_devs
-      > Checking repositories...
-      x HTTP 404 Not Found.
-      ! Repository you provided does not exist: https://api.github.com/repos/r-world-devs/GitMetrics
-      v Set connection to GitHub.
-      i Set up in 0 secs.
 

--- a/tests/testthat/_snaps/set_host.md
+++ b/tests/testthat/_snaps/set_host.md
@@ -62,16 +62,6 @@
       v Set connection to GitLab.
       i Set up in 0 secs.
 
-# When no organizations or repositories are set information is printed
-
-    Code
-      set_github_host(test_gitstats, token = Sys.getenv("GITHUB_PAT"), verbose = TRUE)
-    Message
-      i No `orgs` nor `repos` specified.
-      i Searching scope set to [all].
-      v Set connection to GitHub.
-      i Set up in 0 secs.
-
 # Error shows, when wrong input is passed when setting connection and host is not passed
 
     x Token exists but does not grant access.

--- a/tests/testthat/test-set_host.R
+++ b/tests/testthat/test-set_host.R
@@ -77,18 +77,6 @@ test_that("Set GitLab host with particular repos vector instead of orgs", {
   }
 })
 
-test_that("When no organizations or repositories are set information is printed", {
-  skip_on_cran()
-  test_gitstats <- create_gitstats()
-  expect_snapshot(
-    test_gitstats |>
-      set_github_host(
-        token = Sys.getenv("GITHUB_PAT"),
-        verbose = TRUE
-      )
-  )
-})
-
 test_that("Error shows, when wrong input is passed when setting connection and host is not passed", {
   if (!integration_tests_skipped) {
     test_gitstats <- create_gitstats()

--- a/tests/testthat/test-set_host.R
+++ b/tests/testthat/test-set_host.R
@@ -1,58 +1,53 @@
 test_gitstats <- create_gitstats()
 
-test_that("Set connection returns appropriate messages", {
+test_that("Set connection works as expected", {
   if (!integration_tests_skipped) {
-    expect_snapshot(
+    test_gitstats |>
       set_github_host(
-        gitstats = test_gitstats,
         token = Sys.getenv("GITHUB_PAT"),
         orgs = c("openpharma", "r-world-devs")
       )
+    expect_equal(
+      unlist(test_gitstats$.__enclos_env__$private$hosts[[1]]$.__enclos_env__$private$orgs),
+      c("openpharma", "r-world-devs")
     )
-    expect_snapshot(
-      test_gitstats |> set_gitlab_host(
+    test_gitstats |>
+      set_gitlab_host(
         token = Sys.getenv("GITLAB_PAT_PUBLIC"),
         orgs = c("mbtests")
       )
-    )
-  }
-})
-
-test_that("When empty token for GitHub, GitStats pulls default token", {
-  skip_on_cran()
-  if (!integration_tests_skipped) {
-    expect_snapshot(
-      test_gitstats <- create_gitstats() |>
-        set_github_host(
-          orgs = c("openpharma", "r-world-devs")
-        )
+    expect_equal(
+      unlist(test_gitstats$.__enclos_env__$private$hosts[[2]]$.__enclos_env__$private$orgs),
+      c("mbtests")
     )
   }
 })
 
 test_that("When empty token for GitLab, GitStats pulls default token", {
   if (!integration_tests_skipped) {
-    expect_snapshot(
-      withr::with_envvar(new = c("GITLAB_PAT" = Sys.getenv("GITLAB_PAT_PUBLIC")), {
-        test_gitstats <- create_gitstats() |>
-          set_gitlab_host(
-            orgs = "mbtests"
-          )
-      })
-    )
+    withr::with_envvar(new = c("GITLAB_PAT" = Sys.getenv("GITLAB_PAT_PUBLIC")), {
+      test_gitstats <- create_gitstats() |>
+        set_gitlab_host(
+          orgs = "mbtests",
+          verbose = FALSE
+        )
+      expect_equal(
+        test_gitstats$.__enclos_env__$private$hosts[[1]]$.__enclos_env__$private$token,
+        Sys.getenv("GITLAB_PAT_PUBLIC")
+      )
+    })
   }
 })
 
 test_that("Set GitHub host with particular repos vector instead of orgs", {
   if (!integration_tests_skipped) {
     test_gitstats <- create_gitstats()
-    expect_snapshot(
-      test_gitstats |>
-        set_github_host(
-          token = Sys.getenv("GITHUB_PAT"),
-          repos = c("r-world-devs/GitStats", "r-world-devs/shinyCohortBuilder", "openpharma/GithubMetrics", "openpharma/DataFakeR")
-        )
-    )
+    test_gitstats |>
+      set_github_host(
+        token = Sys.getenv("GITHUB_PAT"),
+        repos = c("r-world-devs/GitStats", "r-world-devs/shinyCohortBuilder", "openpharma/GithubMetrics", "openpharma/DataFakeR"),
+        verbose = FALSE
+      )
     expect_length(
       test_gitstats$.__enclos_env__$private$hosts,
       1
@@ -63,13 +58,12 @@ test_that("Set GitHub host with particular repos vector instead of orgs", {
 test_that("Set GitLab host with particular repos vector instead of orgs", {
   if (!integration_tests_skipped) {
     test_gitstats <- create_gitstats()
-    expect_snapshot(
-      test_gitstats |>
-        set_gitlab_host(
-          token = Sys.getenv("GITLAB_PAT_PUBLIC"),
-          repos = c("mbtests/gitstatstesting", "mbtests/gitstats-testing-2")
-        )
-    )
+    test_gitstats |>
+      set_gitlab_host(
+        token = Sys.getenv("GITLAB_PAT_PUBLIC"),
+        repos = c("mbtests/gitstatstesting", "mbtests/gitstats-testing-2"),
+        verbose = FALSE
+      )
     expect_length(
       test_gitstats$.__enclos_env__$private$hosts,
       1
@@ -102,8 +96,7 @@ test_that("Error shows, when wrong input is passed when setting connection and h
 test_that("Error pops out, when two clients of the same url api are passed as input", {
   if (!integration_tests_skipped) {
     test_gitstats <- create_gitstats()
-    expect_snapshot(
-      error = TRUE,
+    expect_snapshot_error(
       test_gitstats |>
         set_github_host(
           token = Sys.getenv("GITHUB_PAT"),
@@ -153,14 +146,25 @@ test_that("Error pops out when `org` does not exist", {
 
 test_that("When wrong orgs and repos are passed they are excluded but host is created", {
   if (!integration_tests_skipped) {
-    expect_snapshot(
-      test_gitstats <- create_gitstats() |>
-        set_github_host(
-          orgs = c("openpharma", "r_world_devs"),
-          repos = c("r-world-devs/GitStats", "r-world-devs/GitMetrics"),
-          verbose = TRUE,
-          .error = FALSE
-        )
+    test_gitstats <- create_gitstats() |>
+      set_github_host(
+        orgs = c("openpharma", "r_world_devs"),
+        repos = c("r-world-devs/GitStats", "r-world-devs/GitMetrics"),
+        verbose = TRUE,
+        .error = FALSE
+      )
+
+    expect_length(
+      test_gitstats$.__enclos_env__$private$hosts,
+      1
+    )
+    expect_equal(
+      unlist(test_gitstats$.__enclos_env__$private$hosts[[1]]$.__enclos_env__$private$orgs),
+      "openpharma"
+    )
+    expect_equal(
+      unlist(test_gitstats$.__enclos_env__$private$hosts[[1]]$.__enclos_env__$private$repos),
+      "GitStats"
     )
   }
 })


### PR DESCRIPTION
## Description

Print elapsed time after setting GitHub/GitLab hosts (e.g. `ℹ Set up in 1.2 secs.`), matching the pattern already used by all `get_*()` functions. The message respects the `verbose` flag and is not emitted when the host setup errors out.

## Related Issue(s)

Fixes #798

## How to test

1. Run `set_github_host()` or `set_gitlab_host()` with `verbose = TRUE` and verify the elapsed time message appears after `✔ Set connection to GitHub/GitLab.`
2. Run with `verbose = FALSE` and verify no time message is printed.
3. Trigger an error case (e.g. invalid org) and verify no time message is printed.
